### PR TITLE
Added an alternative approach to fetch signing key

### DIFF
--- a/docs-ref-conceptual/install-azure-cli-apt.md
+++ b/docs-ref-conceptual/install-azure-cli-apt.md
@@ -42,6 +42,11 @@ for the Azure CLI. This package has been tested with:
         --keyserver packages.microsoft.com \
         --recv-keys BC528686B50D79E339D3721CEB3E94ADBE1229CF
    ```
+   
+   Alternative approach if you get an error from the command above:
+   ```bash
+   curl -sL "https://packages.microsoft.com/keys/microsoft.asc" | sudo apt-key add -
+   ```  
 
 4. Install the CLI:
 


### PR DESCRIPTION
This approach is needed in some installations. In Ubuntu on WSL for instance, it's not possible to use the original approach without more modifications than found in this document.