### PR TITLE
Fix a casing for "GitHub"

### DIFF
--- a/docs-ref-conceptual/install-azure-cli-linux.md
+++ b/docs-ref-conceptual/install-azure-cli-linux.md
@@ -46,7 +46,7 @@ To learn more about different authentication methods, see [Sign in with Azure CL
 
 ## Troubleshooting
 
-Here are some common problems seen during a manual installation. If you experience a problem not covered here, [file an issue on github](https://github.com/Azure/azure-cli/issues).
+Here are some common problems seen during a manual installation. If you experience a problem not covered here, [file an issue on GitHub](https://github.com/Azure/azure-cli/issues).
 
 ### curl "Object Moved" error
 


### PR DESCRIPTION
Fix a casing for "GitHub".