### PR TITLE
Fix PowerShell command to use the Get-Credential cmdlet

### DIFF
--- a/docs-ref-conceptual/authenticate-azure-cli.md
+++ b/docs-ref-conceptual/authenticate-azure-cli.md
@@ -48,13 +48,11 @@ az login -u <username> -p <password>
 > read -sp "Azure password: " AZ_PASS && echo && az login -u <username> -p $AZ_PASS
 > ```
 >
-> Under PowerShell, use the `Read-Host -AsSecureString` cmdlet and secure string conversion.
+> Under PowerShell, use the `Get-Credential` cmdlet.
 >
 > ```powershell
-> $securePass =  Read-Host "Azure password: " -AsSecureString;
-> $AzPass = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($securePass));
-> az login -u <username> -p $AzPass;
-> $AzPass = ""
+> $AzCred = Get-Credential -UserName <username>
+> az login -u $AzCred.UserName -p $AzCred.GetNetworkCredential().Password
 > ```
 
 ## Sign in with a service principal
@@ -82,13 +80,11 @@ az login --service-principal -u <app-url> -p <password-or-cert> --tenant <tenant
 > read -sp "Azure password: " AZ_PASS && echo && az login --service-principal -u <app-url> -p $AZ_PASS --tenant <tenant>
 > ```
 >
-> Under PowerShell, use the `Read-Host -AsSecureString` cmdlet and secure string conversion.
+> Under PowerShell, use the `Get-Credential` cmdlet.
 >
 > ```powershell
-> $securePass =  Read-Host "Azure password: " -AsSecureString;
-> $AzPass = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($securePass));
-> az login --service-principal -u <app-url> -p $AzPass --tenant <tenant>;
-> $AzPass = ""
+> $AzCred = Get-Credential -UserName <app-url>
+> az login -u $AzCred.UserName -p $AzCred.GetNetworkCredential().Password --tenant <tenant>
 > ```
 
 ## Sign in with a different tenant


### PR DESCRIPTION
Get-Credential cmdlet is better (and simpler) than Read-Host and .NET-based secure string conversion.