### PR TITLE
Document @<json_file> --settings parameter.

### DIFF
--- a/latest/docs-ref-autogen/webapp/config/appsettings.yml
+++ b/latest/docs-ref-autogen/webapp/config/appsettings.yml
@@ -76,7 +76,7 @@ items:
       content: az webapp config appsettings set -g MyResourceGroup -n MyUniqueApp --settings mySetting=value @moreSettings.json
   parameters:
   - name: --settings
-    summary: Space-separated appsettings in a format of <name>=<value>.
+    summary: Space-separated appsettings in a format of either <name>=<value> or @<json_file>.
     description: ''
   - name: --slot -s
     summary: The name of the slot. Default to the productions slot if not specified.


### PR DESCRIPTION
--settings can take `@<json_file>` but this is not documented. It is however shown a few lines above in the sample usage.