### PR TITLE
[testing] enable TOC preview

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -210,7 +210,8 @@
       "showPowerShellPicker": "true",
       "searchScope": [
         "Azure"
-      ]
+      ],
+      "toc_preview": true
     },
     "fileMetadata": {
       "feedback_github_repo": {


### PR DESCRIPTION
Enabling TOC preview (`"toc_preview": true`) so we faithfully represent the TOC's state post-global rollout.