### PR TITLE
Adding missed release notes.

### DIFF
--- a/docs-ref-conceptual/release-notes-azure-cli.md
+++ b/docs-ref-conceptual/release-notes-azure-cli.md
@@ -17,6 +17,12 @@ ms.devlang: azurecli
 
 Version 2.0.64
 
+### ACS
+* BREAKING CHANGE: Removing `--fqdn` flag on az openshift commands
+* Using Azure Red Hat Openshift GA API Version
+* adding customer-admin-group-id flag to "az openshift create"
+* Remove "(PREVIEW)" from "az aks create" option "--network-policy".
+
 ### Appservice
 * Deprecated `functionapp devops-build` command
   * Renamed to `functionapp devops-pipeline`
@@ -29,8 +35,60 @@ Version 2.0.64
 * Added support for `powershell` runtime to `functionapp create` on Windows
 * Added `create-remote-connection` command
 
+### Batch
+* Fix bug in validator for --application-package-references options.
+
+### Botservice
+* [Breaking Change]: `az bot create -v v4 -k webapp` now creates an empty Web App Bot by default (i.e. no bot is deployed to the App Service).
+    * To use the Echo Bot template that was always deployed in the past, use the new `--echo` flag when creating a v4 Web App Bot.
+    * `v3` bot creation does not support using the `--echo` flag.
+* [Breaking Change]: The default value for `--version` is now `v4`, not `v3` (except for `az bot prepare-publish`).
+* [Breaking Change]: `--lang` no longer defaults to `Csharp`. If the command requires `--lang` and it is not provided, the command will error out.
+* [Breaking Change]: The `--appid` and `--password` args for `az bot create` are now required and can be created via `az ad app create`.
+    * Add `--appid` and `--password` validations
+* [Breaking Change]: `az bot create -v v4` does not create or use a Storage Account or Application Insights.
+* [Breaking Change]: Instead of mapping Application Insights regions for `az bot create -v v3`, the command only accepts regions where Application Insights is creatable.
+* [Breaking Change]: `az bot update` is no longer a generic update command, but instead can affect specific properties of a bot.
+* [Breaking Change]: All --lang flags now accept `Javascript` instead of `Node`. `Node` as a `--lang` value is no longer supported.
+* [Breaking Change]: `az bot create -v v4 -k webapp` no longer sets `SCM_DO_BUILD_DURING_DEPLOYMENT` to true. All deployments through Kudu will act according to their default behavior.
+* `az bot download` for bots without .bot files now create the language-specific configuration file with values from the Application Settings for the bot.
+* Add `Typescript` support to `az bot prepare-deploy`
+* Add warning message to `az bot prepare-deploy` for `Javascript` and `Typescript` bots.
++    * This message only appears if the `--code-dir` doesn't contain a package.json.
+* `az bot prepare-deploy` returns `true` if successful and has helpful verbose logging.
+* Add more available Application Insights regions to `az bot create -v v3`
+
+### Configure
+* Support folder based argument default value configurations
+
+### Eventhubs
+* namespace: Added network-rule commands.
+* namespace create/update: Added --default-action argument for network rules.
+
+### Network
+* [BREAKING CHANGE] `vnet create/update`: Replaced `--cache` arugment with `--defer`.
+
+### Policy Insights
+* Add support for `--expand PolicyEvaluationDetails` to query policy evaluation details on the resource.
+
 ### Role
 * [DEPRECATED] Changed `create-for-rbac` hide '--password' argument - support will be removed in May 2019
+
+### Service Bus
+* namespace: Added network-rule commands.
+* namespace create/update: Added --default-action argument for network rules.
+* topic create/update: fixed the command for parameter --max-size to support 10, 20, 40 and 80GB values with premium sku
+
+### SQL
+* Added commands sql virtual-cluster list/show/delete
+
+### VM
+* vmss update: add `--protect-from-scale-in` and `--protect-from-scale-set-actions` to enable updates to the protection policy of VMSS VM instances.
+* vmss update: add `--instance-id` to enable generic update of VMSS VM instances.
+* vmss wait: add `--instance-id`.
+* [new command group] ppg: add `ppg create / delete / list / show / update` for managing Proximity Placement Groups.
+* ppg: add `--ppg` to `vm create`, `vmss create` and `vm availability-set create`
+* image create: expose `--hyper-v-generation` parameter.
 
 ## April 23, 2019
 

--- a/docs-ref-conceptual/release-notes-azure-cli.md
+++ b/docs-ref-conceptual/release-notes-azure-cli.md
@@ -18,13 +18,13 @@ ms.devlang: azurecli
 Version 2.0.64
 
 ### ACS
-* BREAKING CHANGE: Removing `--fqdn` flag on az openshift commands
-* Using Azure Red Hat Openshift GA API Version
-* adding customer-admin-group-id flag to "az openshift create"
-* Remove "(PREVIEW)" from "az aks create" option "--network-policy".
+* [BREAKING CHANGE] Removed `--fqdn` flag on `openshift` commands
+* Changed to use Azure Red Hat Openshift GA API Version
+* Added `customer-admin-group-id` flag to `openshift create`
+* [GA] Removed `(PREVIEW)` from `aks create` option `--network-policy`
 
 ### Appservice
-* Deprecated `functionapp devops-build` command
+* [DEPRECATED] Deprecated `functionapp devops-build` command
   * Renamed to `functionapp devops-pipeline`
 * Fixed getting the correct username for cloudshell which was causing `webapp up` to fail
 * Updated `appservice plan --sku` documentation updated to reflect the supported appserviceplans
@@ -36,59 +36,60 @@ Version 2.0.64
 * Added `create-remote-connection` command
 
 ### Batch
-* Fix bug in validator for --application-package-references options.
+* Fixed bug in validator for `--application-package-references` options
 
 ### Botservice
-* [Breaking Change]: `az bot create -v v4 -k webapp` now creates an empty Web App Bot by default (i.e. no bot is deployed to the App Service).
-    * To use the Echo Bot template that was always deployed in the past, use the new `--echo` flag when creating a v4 Web App Bot.
-    * `v3` bot creation does not support using the `--echo` flag.
-* [Breaking Change]: The default value for `--version` is now `v4`, not `v3` (except for `az bot prepare-publish`).
-* [Breaking Change]: `--lang` no longer defaults to `Csharp`. If the command requires `--lang` and it is not provided, the command will error out.
-* [Breaking Change]: The `--appid` and `--password` args for `az bot create` are now required and can be created via `az ad app create`.
-    * Add `--appid` and `--password` validations
-* [Breaking Change]: `az bot create -v v4` does not create or use a Storage Account or Application Insights.
-* [Breaking Change]: Instead of mapping Application Insights regions for `az bot create -v v3`, the command only accepts regions where Application Insights is creatable.
-* [Breaking Change]: `az bot update` is no longer a generic update command, but instead can affect specific properties of a bot.
-* [Breaking Change]: All --lang flags now accept `Javascript` instead of `Node`. `Node` as a `--lang` value is no longer supported.
-* [Breaking Change]: `az bot create -v v4 -k webapp` no longer sets `SCM_DO_BUILD_DURING_DEPLOYMENT` to true. All deployments through Kudu will act according to their default behavior.
-* `az bot download` for bots without .bot files now create the language-specific configuration file with values from the Application Settings for the bot.
-* Add `Typescript` support to `az bot prepare-deploy`
-* Add warning message to `az bot prepare-deploy` for `Javascript` and `Typescript` bots.
-+    * This message only appears if the `--code-dir` doesn't contain a package.json.
-* `az bot prepare-deploy` returns `true` if successful and has helpful verbose logging.
-* Add more available Application Insights regions to `az bot create -v v3`
+* [BREAKING CHANGE] Changed `bot create -v v4 -k webapp` to create an empty Web App Bot by default (i.e. no bot is deployed to the App Service)
+* Added `--echo` flag to `bot create` to use the old behavior with `-v v4`
+* [BREAKING CHANGE] Changed the default value of  `--version` to `v4`
+  * __NOTE:__ `bot prepare-publish` still uses the its old default
+* [BREAKING CHANGE] Changed `--lang` to no longer default to `Csharp`. If the command requires `--lang` and it is not provided, the command will now error out
+* [BREAKING CHANGE] Changed the `--appid` and `--password` args for `bot create` to be required and can now be created via `ad app create`
+* Added `--appid` and `--password` validation
+* [BREAKING CHANGE] Changed `bot create -v v4` to not create or use a Storage Account or Application Insights
+* [BREAKING CHANGE] Changed `bot create -v v3` to require a region where Application Insights is available
+* [BREAKING CHANGE] Changed `bot update` to now affect only specific properties of a bot
+* [BREAKING CHANGE] Changed `--lang` flags to accept `Javascript` instead of `Node`
+* [BREAKING CHANGE] Removed `Node` as an allowed `--lang` value
+* [BREAKING CHANGE] Changed `bot create -v v4 -k webapp` to no longer set `SCM_DO_BUILD_DURING_DEPLOYMENT` to true. All deployments through Kudu will act according to their default behavior
+* Changed `bot download` for bots without `.bot` files to create the language-specific configuration file with values from the Application Settings for the bot
+* Added `Typescript` support to `bot prepare-deploy`
+* Added warning message to `bot prepare-deploy` for `Javascript` and `Typescript` bots for when `--code-dir` does not contain `package.json`
+* Changed `bot prepare-deploy` to return `true` if successful
+* Added verbose logging to `bot prepare-deploy`
+* Added more available Application Insights regions to `az bot create -v v3`
 
 ### Configure
-* Support folder based argument default value configurations
+* Added support for folder based argument default value configurations
 
 ### Eventhubs
-* namespace: Added network-rule commands.
-* namespace create/update: Added --default-action argument for network rules.
+* Added `namespace network-rule` commands
+* Added `--default-action` argument for network rules to `namespace [create|update]`
 
 ### Network
-* [BREAKING CHANGE] `vnet create/update`: Replaced `--cache` arugment with `--defer`.
+* [BREAKING CHANGE] Replaced `--cache` arugment with `--defer` for `vnet [create|update]` 
 
 ### Policy Insights
-* Add support for `--expand PolicyEvaluationDetails` to query policy evaluation details on the resource.
+* Added support for `--expand PolicyEvaluationDetails` to query policy evaluation details on the resource
 
 ### Role
 * [DEPRECATED] Changed `create-for-rbac` hide '--password' argument - support will be removed in May 2019
 
 ### Service Bus
-* namespace: Added network-rule commands.
-* namespace create/update: Added --default-action argument for network rules.
-* topic create/update: fixed the command for parameter --max-size to support 10, 20, 40 and 80GB values with premium sku
+* Added `namespace network-rule` commands
+* Added `--default-action` argument for network rules to `namespace [create|update]`
+* Fixed `topic [create|update]` to allow `--max-size` support for 10, 20, 40 and 80GB values with premium SKU
 
 ### SQL
-* Added commands sql virtual-cluster list/show/delete
+* Added `sql virtual-cluster [list|show|delete]` commands
 
 ### VM
-* vmss update: add `--protect-from-scale-in` and `--protect-from-scale-set-actions` to enable updates to the protection policy of VMSS VM instances.
-* vmss update: add `--instance-id` to enable generic update of VMSS VM instances.
-* vmss wait: add `--instance-id`.
-* [new command group] ppg: add `ppg create / delete / list / show / update` for managing Proximity Placement Groups.
-* ppg: add `--ppg` to `vm create`, `vmss create` and `vm availability-set create`
-* image create: expose `--hyper-v-generation` parameter.
+* Added `--protect-from-scale-in` and `--protect-from-scale-set-actions` to `vmss update` to enable updates to the protection policy of VMSS VM instances
+* Added `--instance-id` to `vmss update` to enable generic update of VMSS VM instances
+* Added `--instance-id` to `vmss wait`
+* Added new `ppg` command group for manging Proximity Placement Groups
+* Added `--ppg` to `[vm|vmss] create` and `vm availability-set create` for managing PPGs
+* Added `--hyper-v-generation` parameter to `image create`
 
 ## April 23, 2019
 


### PR DESCRIPTION
The last release was hurried, and we missed a good chunk of the release notes that should have been part of these docs.

Note, once https://github.com/Azure/azure-cli/issues/8592 is finished, the process will be much simplified and we shouldn't have this sort of mistake again.