### PR TITLE
remove top level service mappings for a cmd-oriented TOC

### DIFF
--- a/titleMapping.json
+++ b/titleMapping.json
@@ -3,14 +3,6 @@
 		"TocTitle": "Reference",
 		"PageTitle": "Azure CLI 2.0: Command reference"
 	},
-	"az account": {
-		"TocTitle": "Subscriptions",
-		"PageTitle": "Subscriptions"
-	},
-	"az acr": {
-		"TocTitle": "Container Registry",
-		"PageTitle": "Container Registry"
-	},
 	"az acr credential": {
 		"TocTitle": "Credentials",
 		"PageTitle": "Container Registry credentials"
@@ -19,10 +11,6 @@
 		"TocTitle": "Repositories",
 		"PageTitle": "Container Registry repositories"
 	},
-	"az acs": {
-		"TocTitle": "Container Service",
-		"PageTitle": "Container Service"
-	},
 	"az acs dcos": {
 		"TocTitle": "DC/OS",
 		"PageTitle": "Container Service - DC/OS"
@@ -30,10 +18,6 @@
 	"az acs kubernetes": {
 		"TocTitle": "Kubernetes",
 		"PageTitle": "Container Service - Kubernetes"
-	},
-	"az ad": {
-		"TocTitle": "Azure Active Directory",
-		"PageTitle": "Azure Active Directory (AAD)"
 	},
 	"az ad app": {
 		"TocTitle": "Applications",
@@ -50,10 +34,6 @@
 	"az ad user": {
 		"TocTitle": "Users",
 		"PageTitle": "AAD users"
-	},
-	"az appservice": {
-		"TocTitle": "App Service",
-		"PageTitle": "App Service"
 	},
 	"az appservice plan": {
 		"TocTitle": "Plans",
@@ -106,10 +86,6 @@
 	"az appservice web source-control": {
 		"TocTitle": "Source control",
 		"PageTitle": "Web Apps source control"
-	},
-	"az batch": {
-		"TocTitle": "Batch",
-		"PageTitle": "Batch"
 	},
 	"az batch account": {
 		"TocTitle": "Accounts",
@@ -223,25 +199,9 @@
 		"TocTitle": "Subtasks",
 		"PageTitle": "Subtasks of batch tasks"
 	},
-	"az cdn": {
-		"TocTitle": "CDN",
-		"PageTitle": "CDN"
-	},
-	"az cloud": {
-		"TocTitle": "Cloud management",
-		"PageTitle": "Cloud management"
-	},
 	"az cognitiveservices": {
 		"TocTitle": "Cognitive Services",
 		"PageTitle": "Cognitive Services"
-	},
-	"az component": {
-		"TocTitle": "Components",
-		"PageTitle": "Components"
-	},
-	"az container": {
-		"TocTitle": "Container",
-		"PageTitle": "Container"
 	},
 	"az container build": {
 		"TocTitle": "Builds",
@@ -250,18 +210,6 @@
 	"az container release": {
 		"TocTitle": "Releases",
 		"PageTitle": "Container releases"
-	},
-	"az context": {
-		"TocTitle": "Contexts",
-		"PageTitle": "Contexts"
-	},
-	"az cosmosdb": {
-		"TocTitle": "Cosmos DB",
-		"PageTitle": "Cosmos DB"
-		},
-	"az dla": {
-		"TocTitle": "Data Lake Analytics",
-		"PageTitle": "Data Lake Analytics"
 	},
 	"az dla account": {
 		"TocTitle": "Accounts",
@@ -359,22 +307,6 @@
 		"TocTitle": "Access",
 		"PageTitle": "Data Lake Store file system access and permissions"
 	},
-	"az disk": {
-		"TocTitle": "Managed Disks",
-		"PageTitle": "Managed Disks"
-	},
-	"az feature": {
-		"TocTitle": "Resource provider features",
-		"PageTitle": "Resource provider features"
-	},
-	"az functionapp": {
-		"TocTitle": "Functions",
-		"PageTitle": "Functions"
-	},
-	"az group": {
-		"TocTitle": "Resource groups",
-		"PageTitle": "Resource groups"
-	},
 	"az group deployment": {
 		"TocTitle": "Deployments",
 		"PageTitle": "Deployments"
@@ -382,18 +314,6 @@
 	"az group deployment operation": {
 		"TocTitle": "Operations",
 		"PageTitle": "Deployment operations"
-	},
-	"az hdinsight": {
-		"TocTitle": "HDInsight",
-		"PageTitle": "HDInsight"
-	},
-	"az image": {
-		"TocTitle": "VM Images",
-		"PageTitle": "Virtual Machine Images"
-	},
-	"az iot": {
-		"TocTitle": "IoT",
-		"PageTitle": "IoT"
 	},
 	"az iot device": {
 		"TocTitle": "Devices",
@@ -418,10 +338,6 @@
 	"az iot hub policy": {
 		"TocTitle": "Policies",
 		"PageTitle": "IoT hub policies"
-	},
-	"az keyvault": {
-		"TocTitle": "Key Vault",
-		"PageTitle": "Key Vault"
 	},
 	"az keyvault certificate": {
 		"TocTitle": "Certificates",
@@ -451,10 +367,6 @@
 		"TocTitle": "Secrets",
 		"PageTitle": "Key Vault secrets"
 	},
-	"az lab": {
-		"TocTitle": "DevTest Lab",
-		"PageTitle": "Dev/Test Lab"
-	},
 	"az lab artifact": {
 		"TocTitle": "Artifacts",
 		"PageTitle": "Dev/Test Lab artifacts"
@@ -483,21 +395,9 @@
 		"TocTitle": "Virtual networks",
 		"PageTitle": "Dev/Test Lab virtual networks"
 	},
-	"az lock": {
-		"TocTitle": "Locks",
-		"PageTitle": "Resource locks"
-	},
-	"az managedapp": {
-		"TocTitle": "Managed App",
-		"PageTitle": "Managed applications"
-	},
 	"az managedapp definition": {
 		"TocTitle": "Definition",
 		"PageTitle": "Managed application definitions"
-	},
-	"az monitor": {
-		"TocTitle": "Monitoring",
-		"PageTitle": "Monitoring "
 	},
 	"az monitor activity-log": {
 		"TocTitle": "Activity log",
@@ -527,10 +427,6 @@
 		"TocTitle": "Metrics",
 		"PageTitle": "Monitoring metrics"
 	},
-	"az mysql": {
-		"TocTitle": "MySQL",
-		"PageTitle": "Azure Database for MySQL"
-	},
 	"az mysql db": {
 		"TocTitle": "Databases",
 		"PageTitle": "Azure Database for MySQL databases"
@@ -550,10 +446,6 @@
 	"az mysql server-logs": {
 		"TocTitle": "Server logs",
 		"PageTitle": "Azure Database for MySQL server logs"
-	},
-	"az network": {
-		"TocTitle": "Networking",
-		"PageTitle": "Networking"
 	},
 	"az network application-gateway": {
 		"TocTitle": "Application Gateway",
@@ -779,10 +671,6 @@
 		"TocTitle": "Shared keys",
 		"PageTitle": "VPN shared keys"
 	},
-	"az policy": {
-		"TocTitle": "Resource policies",
-		"PageTitle": "Resource policies"
-	},
 	"az policy assignment": {
 		"TocTitle": "Assignments",
 		"PageTitle": "Resource policy assignments"
@@ -790,10 +678,6 @@
 	"az policy definition": {
 		"TocTitle": "Definitions",
 		"PageTitle": "Resource policy definitions"
-	},
-	"az postgres": {
-		"TocTitle": "PostgreSQL",
-		"PageTitle": "Azure Database for PostgreSQL"
 	},
 	"az postgres db": {
 		"TocTitle": "Databases",
@@ -815,29 +699,13 @@
 		"TocTitle": "Server logs",
 		"PageTitle": "Azure Database for PostgreSQL server logs"
 	},
-	"az provider": {
-		"TocTitle": "Resource providers",
-		"PageTitle": "Resource providers"
-	},
-	"az redis": {
-		"TocTitle": "Redis Cache",
-		"PageTitle": "Redis Cache"
-	},
 	"az redis patch-schedule": {
 		"TocTitle": "Patch schedules",
 		"PageTitle": "Patch schedules"
 	},
-	"az resource": {
-		"TocTitle": "Resources",
-		"PageTitle": "Resources"
-	},
 	"az resource link": {
 		"TocTitle": "Links",
 		"PageTitle": "Resource links"
-	},
-	"az role": {
-		"TocTitle": "Roles",
-		"PageTitle": "Roles"
 	},
 	"az role assignment": {
 		"TocTitle": "Assignments",
@@ -846,18 +714,6 @@
 	"az role definition": {
 		"TocTitle": "Definitions",
 		"PageTitle": "Role definitions"
-	},
-	"az sf": {
-		"TocTitle": "Service Fabric",
-		"PageTitle": "Service Fabric"
-	},
-	"az snapshot": {
-		"TocTitle": "VM Snapshots",
-		"PageTitle": "VM Snapshots"
-	},
-	"az sql": {
-		"TocTitle": "SQL",
-		"PageTitle": "SQL"
 	},
 	"az sql db": {
 		"TocTitle": "Databases",
@@ -914,10 +770,6 @@
 	"az sql server service-objective": {
 		"TocTitle": "Service objectives",
 		"PageTitle": "SQL Server service objectives"
-	},
-	"az storage": {
-		"TocTitle": "Storage",
-		"PageTitle": "Storage"
 	},
 	"az storage account": {
 		"TocTitle": "Accounts",
@@ -1035,18 +887,6 @@
 		"TocTitle": "Policies",
 		"PageTitle": "Table policies"
 	},
-	"az tag": {
-		"TocTitle": "Resource tags",
-		"PageTitle": "Resource tags"
-	},
-	"az taskhelp": {
-		"TocTitle": "Help content",
-		"PageTitle": "Help content"
-	},
-	"az vm": {
-		"TocTitle": "Virtual Machines",
-		"PageTitle": "Virtual Machines (VM)"
-	},
 	"az vm access": {
 		"TocTitle": "User access",
 		"PageTitle": "VM user access"
@@ -1095,10 +935,6 @@
 		"TocTitle": "Users",
 		"PageTitle": "VM users"
 	},
-	"az vmss": {
-		"TocTitle": "VM Scale Sets",
-		"PageTitle": "VM scale Sets (VMSS)"
-	},
 	"az vmss diagnostics": {
 		"TocTitle": "Diagnostics",
 		"PageTitle": "VMSS diagnostics"
@@ -1118,13 +954,5 @@
 	"az vmss nic": {
 		"TocTitle": "Network interfaces",
 		"PageTitle": "VMSS network interfaces"
-	},
-	"az webapp": {
-		"TocTitle": "Web Apps",
-		"PageTitle": "Web Apps"
-	},
-	"az ams": {
-		"TocTitle": "Azure Media Services",
-		"PageTitle": "Azure Media Services (AMS)"
-	}	
+	}
 }


### PR DESCRIPTION
Testing a TOC change that would remove the service mappings so it's top-level command focused, but leave the underlying sub-section renames that bring clarity to the command scope.