### PR TITLE
Update CLI extensions available doc

### DIFF
--- a/docs-ref-conceptual/azure-cli-extensions-list.md
+++ b/docs-ref-conceptual/azure-cli-extensions-list.md
@@ -4,7 +4,7 @@ description: A complete list of the officially supported extensions for the Azur
 author: sptramer
 ms.author: sttramer
 manager: carmonm
-ms.date: 07/31/2019
+ms.date: 08/06/2019
 ms.topic: article
 ms.prod: azure
 ms.technology: azure-cli
@@ -30,8 +30,8 @@ az extension list-available --output table
 | [application-insights](https://github.com/Azure/azure-cli-extensions/tree/master/src/application-insights) | 0.1.1 | Support for managing Application Insights components and querying metrics, events, and logs from such components. | Yes |
 | [azure-batch-cli-extensions](https://github.com/Azure/azure-batch-cli-extensions) | 4.0.0 | Additional commands for working with Azure Batch service |  |
 | [azure-cli-iot-ext](https://github.com/azure/azure-iot-cli-extension) | 0.7.1 | Provides the data plane command layer for Azure IoT Hub, IoT Edge and IoT Device Provisioning Service |  |
-| [azure-cli-ml](https://docs.microsoft.com/en-us/azure/machine-learning/service/) | 1.0.53.1 | Microsoft Azure Command-Line Tools AzureML Command Module |  |
-| [azure-devops](https://github.com/Microsoft/azure-devops-cli-extension) | 0.11.0 | Tools for managing Azure DevOps. |  |
+| [azure-cli-ml](https://docs.microsoft.com/en-us/azure/machine-learning/service/) | 1.0.55 | Microsoft Azure Command-Line Tools AzureML Command Module |  |
+| [azure-devops](https://github.com/Microsoft/azure-devops-cli-extension) | 0.12.0 | Tools for managing Azure DevOps. |  |
 | [azure-firewall](https://github.com/Azure/azure-cli-extensions/tree/master/src/azure-firewall) | 0.1.3 | Manage Azure Firewall resources. | Yes |
 | [db-up](https://github.com/Azure/azure-cli-extensions/tree/master/src/db-up) | 0.1.13 | Additional commands to simplify Azure Database workflows. | Yes |
 | [dev-spaces](https://github.com/Azure/azure-cli-extensions) | 1.0.3 | Dev Spaces provides a rapid, iterative Kubernetes development experience for teams. |  |


### PR DESCRIPTION
Update CLI extensions available doc.
 Triggered by Azure/azure-cli-extensions - TRAVIS_BUILD_ID=568528556
https://github.com/Azure/azure-cli-extensions/commit/b403b64e117682d47a8c48e78fe7746283a6cda1