### PR TITLE
L128786: Fixing link to bookmark

### DIFF
--- a/docs-ref-conceptual/install-azure-cli-macos.md
+++ b/docs-ref-conceptual/install-azure-cli-macos.md
@@ -57,7 +57,7 @@ brew link --overwrite python3
 
 ### CLI version 1.x is installed
 
-If an out-of-date version was installed, it could be because of a stale homebrew cache. Follow the [update](#Update) instructions.
+If an out-of-date version was installed, it could be because of a stale homebrew cache. Follow the [update](#update) instructions.
 
 ### Proxy blocks connection
 


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: The bookmark #Update is not working in the source nor loc page since it was written with uppercase instead of lowercase.