### PR TITLE
openssl-devel is required for ssl

### DIFF
--- a/docs-ref-conceptual/install-azure-cli-zypper.md
+++ b/docs-ref-conceptual/install-azure-cli-zypper.md
@@ -60,7 +60,7 @@ Here are some common problems seen when installing with `zypper`. If you experie
 
 On SLES 12, the defualt python3 package is 3.4 and not supported by Azure CLI. You can first build a higher version python3 from source. Then you can download the Azure CLI package and install it without dependency.
 ```bash
-$ sudo zypper install -y gcc gcc-c++ make ncurses patch wget tar zlib-devel zlib
+$ sudo zypper install -y gcc gcc-c++ make ncurses patch wget tar zlib-devel zlib openssl-devel
 # Download Python source code
 $ PYTHON_VERSION="3.6.9"
 $ PYTHON_SRC_DIR=$(mktemp -d)


### PR DESCRIPTION
openssl-devel must be installed for some image like `SUSE:SLES-SAP:12-SP3:2019.11.18`.

```
> PYTHONPATH=/usr/lib64/az/lib/python3.6/site-packages python3
Python 3.6.9 (default, Jan 29 2020, 07:09:55)
[GCC 4.8.5] on linux
Type "help", "copyright", "credits" or "license" for more information.
Traceback (most recent call last):
  File "/etc/pythonstart", line 7, in <module>
    import readline
ModuleNotFoundError: No module named 'readline'
>>> import ssl
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.6/ssl.py", line 101, in <module>
    import _ssl             # if we can't import it, let the error propagate
ModuleNotFoundError: No module named '_ssl'
```

Error on import ssl.
az login fails because of this.

We need openssl-devel.
```
> sudo zypper install openssl-devel
```
Then confiugre, make, makeinstall

```
> PYTHONPATH=/usr/lib64/az/lib/python3.6/site-packages python3
Python 3.6.9 (default, Jan 29 2020, 07:16:59)
[GCC 4.8.5] on linux
Type "help", "copyright", "credits" or "license" for more information.
Traceback (most recent call last):
  File "/etc/pythonstart", line 7, in <module>
    import readline
ModuleNotFoundError: No module named 'readline'
>>> import ssl
>>>
```
Now it is working fine.