### PR TITLE
(AzureCXP) fixes MicrosoftDocs/azure-docs-cli#1815

### DIFF
--- a/docs-ref-conceptual/install-azure-cli-yum.md
+++ b/docs-ref-conceptual/install-azure-cli-yum.md
@@ -63,6 +63,11 @@ $ sudo yumdownloader azure-cli
 $ sudo rpm -ivh --nodeps azure-cli-*.rpm
 ```
 
+If you have setup python3 but are still getting an error `python3: command not found` when trying to run the cli, you need to add it to your path.
+```bash
+$ scl enable rh-python36 bash
+```
+
 ### Proxy blocks connection
 
 [!INCLUDE[configure-proxy](includes/configure-proxy.md)]


### PR DESCRIPTION
Adding a note about adding rh-python36 to path on RHEL 7.6