### PR TITLE
Add remove step to Powershell install command

### DIFF
--- a/docs-ref-conceptual/install-azure-cli-windows.md
+++ b/docs-ref-conceptual/install-azure-cli-windows.md
@@ -31,7 +31,7 @@ When the installer asks if it can make changes to your computer, click the "Yes"
 You can also install the Azure CLI using PowerShell. Start PowerShell as administrator and run the following command:
 
    ```PowerShell
-   Invoke-WebRequest -Uri https://aka.ms/installazurecliwindows -OutFile .\AzureCLI.msi; Start-Process msiexec.exe -Wait -ArgumentList '/I AzureCLI.msi /quiet'
+   Invoke-WebRequest -Uri https://aka.ms/installazurecliwindows -OutFile .\AzureCLI.msi; Start-Process msiexec.exe -Wait -ArgumentList '/I AzureCLI.msi /quiet'; rm .\AzureCLI.msi
    ```
 This will download and install the latest version of the Azure CLI for Windows. If you already have a version installed, it will update the existing version. After the installation is complete, you will need to reopen PowerShell to use the Azure CLI.
 


### PR DESCRIPTION
Most CLI based installers (apt, yum, chocolatey, scoop) will avoid cluttering the current directory with files. Adding an rm step will cleanup after itself.

An alternative option is to keep the installer versioned, in a specific location like AppData. I felt the change here was small enough, that it would lead to the smallest impact while keeping the directory clean.