### PR TITLE
Fix pg version: "11.0" => "11"

### DIFF
--- a/latest/docs-ref-autogen/postgres/server.yml
+++ b/latest/docs-ref-autogen/postgres/server.yml
@@ -34,7 +34,7 @@ items:
         az postgres server create -l northeurope -g testgroup -n testsvr -u username -p password \
             --sku-name B_Gen5_1 --ssl-enforcement Enabled --public-network-access Disabled \
             --backup-retention 10 --geo-redundant-backup Enabled --storage-size 51200 \
-            --tags "key=value" --version 11.0
+            --tags "key=value" --version 11
   parameters:
   - isRequired: true
     name: --name -n


### PR DESCRIPTION
"Version '11.0' is not supported." is the error message we get when we request postgres server creation.
"11" instead of "11.0" must be used.