### PR TITLE
Out of band IoT CLI reference docs update for Digital Twins content

### DIFF
--- a/2017-03-09-profile/docs-ref-autogen/ext/azure-iot/dt.yml
+++ b/2017-03-09-profile/docs-ref-autogen/ext/azure-iot/dt.yml
@@ -1,0 +1,253 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt
+  name: az dt
+  summary: Manage Azure Digital Twins (ADT) solutions & infrastructure.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_create
+  - ext_azure-iot_az_dt_delete
+  - ext_azure-iot_az_dt_list
+  - ext_azure-iot_az_dt_show
+- uid: ext_azure-iot_az_dt_create
+  name: az dt create
+  summary: Create a new Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Create instance in target resource group with default location.
+    syntax:
+      content: az dt create -n {instance_name} -g {resouce_group} -l eastus2euap
+  - summary: Create instance in target resource group with specified location and tags.
+    syntax:
+      content: az dt create -n {instance_name} -g {resouce_group} -l westcentralus --tags "a=b;c=d"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --location -l
+    summary: Digital Twins instance location. You can configure the default location using `az configure --defaults location=&lt;name&gt;`.
+    description: ''
+  - isRequired: true
+    name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --tags
+    summary: 'Digital Twins instance tags. Property bag in key-value pairs with the following format: a=b;c=d.'
+    description: ''
+- uid: ext_azure-iot_az_dt_delete
+  name: az dt delete
+  summary: Delete an existing Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Delete an arbitrary instance.
+    syntax:
+      content: az dt delete -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_list
+  name: az dt list
+  summary: List the collection of Digital Twins instances by subscription or resource group.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List all instances in the current subscription.
+    syntax:
+      content: az dt list
+  - summary: List all instances in target resource group and output in table format.
+    syntax:
+      content: az dt list -g {resource_group} --output table
+  - summary: List all instances in subscription that meet a condition.
+    syntax:
+      content: az dt list --query "[?contains(name, 'Production')]"
+  - summary: Count instances that meet condition.
+    syntax:
+      content: az dt list --query "length([?contains(name, 'Production')])"
+  parameters:
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_show
+  name: az dt show
+  summary: Show an existing Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show an instance.
+    syntax:
+      content: az dt show -n {instance_name}
+  - summary: Show an instance and project certain properties.
+    syntax:
+      content: az dt show -n {instance_name} --query "{Endpoint:hostName, Location:location}"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_create
+  name: az dt create
+  summary: Create a new Digital Twins instance.
+- uid: ext_azure-iot_az_dt_delete
+  name: az dt delete
+  summary: Delete an existing Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint
+  name: az dt endpoint
+  summary: Manage and configure Digital Twins instance endpoints.
+- uid: ext_azure-iot_az_dt_endpoint_create
+  name: az dt endpoint create
+  summary: Add egress endpoints to a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_create_eventgrid
+  name: az dt endpoint create eventgrid
+  summary: Adds an EventGrid Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_eventhub
+  name: az dt endpoint create eventhub
+  summary: Adds an EventHub endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_servicebus
+  name: az dt endpoint create servicebus
+  summary: Adds a ServiceBus Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_delete
+  name: az dt endpoint delete
+  summary: Remove an endpoint from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_list
+  name: az dt endpoint list
+  summary: List all egress endpoints configured on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_show
+  name: az dt endpoint show
+  summary: Show details of an endpoint configured on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_list
+  name: az dt list
+  summary: List the collection of Digital Twins instances by subscription or resource group.
+- uid: ext_azure-iot_az_dt_model
+  name: az dt model
+  summary: Manage DTDL models and definitions on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_model_create
+  name: az dt model create
+  summary: Uploads one or more models. When any error occurs, no models are uploaded.
+- uid: ext_azure-iot_az_dt_model_delete
+  name: az dt model delete
+  summary: Delete a model. A model can only be deleted if no other models reference it.
+- uid: ext_azure-iot_az_dt_model_list
+  name: az dt model list
+  summary: List model metadata, definitions and dependencies.
+- uid: ext_azure-iot_az_dt_model_show
+  name: az dt model show
+  summary: Retrieve a target model or model definition.
+- uid: ext_azure-iot_az_dt_model_update
+  name: az dt model update
+  summary: Updates the metadata for a model. Currently a model can only be decommisioned.
+- uid: ext_azure-iot_az_dt_role_assignment
+  name: az dt role-assignment
+  summary: Manage RBAC role assignments for a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_role_assignment_create
+  name: az dt role-assignment create
+  summary: Assign a user, group or service principal to a role against a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_role_assignment_delete
+  name: az dt role-assignment delete
+  summary: Remove a user, group or service principal role assignment from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_role_assignment_list
+  name: az dt role-assignment list
+  summary: List the existing role assignments of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route
+  name: az dt route
+  summary: Manage and configure event routes.
+- uid: ext_azure-iot_az_dt_route_create
+  name: az dt route create
+  summary: Add an event route to a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_delete
+  name: az dt route delete
+  summary: Remove an event route from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_list
+  name: az dt route list
+  summary: List the configured event routes of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_show
+  name: az dt route show
+  summary: Show details of an event route configured on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_show
+  name: az dt show
+  summary: Show an existing Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin
+  name: az dt twin
+  summary: Manage and configure the digital twins of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_component
+  name: az dt twin component
+  summary: Show and update the digital twin components of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_component_show
+  name: az dt twin component show
+  summary: Show details of a digital twin component.
+- uid: ext_azure-iot_az_dt_twin_component_update
+  name: az dt twin component update
+  summary: Update a digital twin component via JSON patch specification.
+- uid: ext_azure-iot_az_dt_twin_create
+  name: az dt twin create
+  summary: Create a digital twin on an instance.
+- uid: ext_azure-iot_az_dt_twin_delete
+  name: az dt twin delete
+  summary: Remove a digital twin. All relationships referencing this twin must already be deleted.
+- uid: ext_azure-iot_az_dt_twin_query
+  name: az dt twin query
+  summary: Query the digital twins of an instance. Allows traversing relationships and filtering by property values.
+- uid: ext_azure-iot_az_dt_twin_relationship
+  name: az dt twin relationship
+  summary: Manage and configure the digital twin relationships of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_relationship_create
+  name: az dt twin relationship create
+  summary: Create a relationship between source and target digital twins.
+- uid: ext_azure-iot_az_dt_twin_relationship_delete
+  name: az dt twin relationship delete
+  summary: Delete a digital twin relationship on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_relationship_list
+  name: az dt twin relationship list
+  summary: List the relationships of a digital twin.
+- uid: ext_azure-iot_az_dt_twin_relationship_show
+  name: az dt twin relationship show
+  summary: Show details of a digital twin relationship.
+- uid: ext_azure-iot_az_dt_twin_relationship_update
+  name: az dt twin relationship update
+  summary: Updates the properties of a relationship between two digital twins via JSON patch specification.
+- uid: ext_azure-iot_az_dt_twin_show
+  name: az dt twin show
+  summary: Show the details of a digital twin.
+- uid: ext_azure-iot_az_dt_twin_telemetry
+  name: az dt twin telemetry
+  summary: Test and validate the event routes and endpoints of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_telemetry_send
+  name: az dt twin telemetry send
+  summary: Sends telemetry on behalf of a digital twin. If component path is provided the emitted telemetry is on behalf of the component.
+- uid: ext_azure-iot_az_dt_twin_update
+  name: az dt twin update
+  summary: Update an instance digital twin via JSON patch specification.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Manage Azure Digital Twins (ADT) solutions & infrastructure.

--- a/2017-03-09-profile/docs-ref-autogen/ext/azure-iot/dt/endpoint.yml
+++ b/2017-03-09-profile/docs-ref-autogen/ext/azure-iot/dt/endpoint.yml
@@ -1,0 +1,112 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_endpoint
+  name: az dt endpoint
+  summary: Manage and configure Digital Twins instance endpoints.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_endpoint_delete
+  - ext_azure-iot_az_dt_endpoint_list
+  - ext_azure-iot_az_dt_endpoint_show
+- uid: ext_azure-iot_az_dt_endpoint_delete
+  name: az dt endpoint delete
+  summary: Remove an endpoint from a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Remove an endpoint from an instance.
+    syntax:
+      content: az dt endpoint delete -n {instance_name} --endpoint-name {endpoint_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_endpoint_list
+  name: az dt endpoint list
+  summary: List all egress endpoints configured on a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List all egress endpoints configured on an instance.
+    syntax:
+      content: az dt endpoint list -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_endpoint_show
+  name: az dt endpoint show
+  summary: Show details of an endpoint configured on a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show a desired endpoint by name on an instance.
+    syntax:
+      content: az dt endpoint show -n {instance_name} --endpoint-name {endpoint_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_endpoint_create
+  name: az dt endpoint create
+  summary: Add egress endpoints to a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_create_eventgrid
+  name: az dt endpoint create eventgrid
+  summary: Adds an EventGrid Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_eventhub
+  name: az dt endpoint create eventhub
+  summary: Adds an EventHub endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_servicebus
+  name: az dt endpoint create servicebus
+  summary: Adds a ServiceBus Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_delete
+  name: az dt endpoint delete
+  summary: Remove an endpoint from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_list
+  name: az dt endpoint list
+  summary: List all egress endpoints configured on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_show
+  name: az dt endpoint show
+  summary: Show details of an endpoint configured on a Digital Twins instance.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Manage and configure Digital Twins instance endpoints.

--- a/2017-03-09-profile/docs-ref-autogen/ext/azure-iot/dt/endpoint/create.yml
+++ b/2017-03-09-profile/docs-ref-autogen/ext/azure-iot/dt/endpoint/create.yml
@@ -1,0 +1,153 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_endpoint_create
+  name: az dt endpoint create
+  summary: Add egress endpoints to a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_endpoint_create_eventgrid
+  - ext_azure-iot_az_dt_endpoint_create_eventhub
+  - ext_azure-iot_az_dt_endpoint_create_servicebus
+- uid: ext_azure-iot_az_dt_endpoint_create_eventgrid
+  name: az dt endpoint create eventgrid
+  summary: Adds an EventGrid Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Adds an EventGrid Topic endpoint to a target instance.
+    syntax:
+      content: az dt endpoint create eventgrid --endpoint-name {endpoint_name} --eventgrid-resource-group {eventgrid_resource_group} --eventgrid-topic {eventgrid_topic_name} -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --tags
+    summary: 'Digital Twins endpoint tags. Property bag in key-value pairs with the following format: a=b;c=d.'
+    description: ''
+  - isRequired: true
+    name: --egg --eventgrid-resource-group
+    summary: Name of EventGrid Topic resource group.
+    description: ''
+  - isRequired: true
+    name: --egt --eventgrid-topic
+    summary: Name of EventGrid Topic to integrate with.
+    description: ''
+- uid: ext_azure-iot_az_dt_endpoint_create_eventhub
+  name: az dt endpoint create eventhub
+  summary: Adds an EventHub endpoint to a Digital Twins instance. Requires pre-created resource.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Adds an EventHub endpoint to a target instance.
+    syntax:
+      content: az dt endpoint create eventhub --endpoint-name {endpoint_name} --eventhub-resource-group {eventhub_resource_group} --eventhub-namespace {eventhub_namespace} --eventhub {eventhub_name} --eventhub-policy {eventhub_policy} -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --tags
+    summary: 'Digital Twins endpoint tags. Property bag in key-value pairs with the following format: a=b;c=d.'
+    description: ''
+  - isRequired: true
+    name: --eh --eventhub
+    summary: Name of EventHub to integrate with.
+    description: ''
+  - isRequired: true
+    name: --ehg --eventhub-resource-group
+    summary: Name of EventHub resource group.
+    description: ''
+  - isRequired: true
+    name: --ehn --eventhub-namespace
+    summary: EventHub Namespace identifier.
+    description: ''
+  - isRequired: true
+    name: --ehp --eventhub-policy
+    summary: EventHub policy to use for endpoint configuration.
+    description: ''
+- uid: ext_azure-iot_az_dt_endpoint_create_servicebus
+  name: az dt endpoint create servicebus
+  summary: Adds a ServiceBus Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Adds a ServiceBus Topic endpoint to a target instance.
+    syntax:
+      content: az dt endpoint create servicebus --endpoint-name {endpoint_name} --servicebus-resource-group {servicebus_resource_group} --servicebus-namespace {servicebus_namespace} --servicebus-topic {servicebus_topic_name} --servicebus-policy {servicebus_policy} -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --tags
+    summary: 'Digital Twins endpoint tags. Property bag in key-value pairs with the following format: a=b;c=d.'
+    description: ''
+  - isRequired: true
+    name: --sbg --servicebus-resource-group
+    summary: Name of ServiceBus resource group.
+    description: ''
+  - isRequired: true
+    name: --sbn --servicebus-namespace
+    summary: ServiceBus Namespace identifier.
+    description: ''
+  - isRequired: true
+    name: --sbp --servicebus-policy
+    summary: ServiceBus Topic policy to use for endpoint configuration.
+    description: ''
+  - isRequired: true
+    name: --sbt --servicebus-topic
+    summary: Name of ServiceBus Topic to integrate with.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_endpoint_create_eventgrid
+  name: az dt endpoint create eventgrid
+  summary: Adds an EventGrid Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_eventhub
+  name: az dt endpoint create eventhub
+  summary: Adds an EventHub endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_servicebus
+  name: az dt endpoint create servicebus
+  summary: Adds a ServiceBus Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Add egress endpoints to a Digital Twins instance.

--- a/2017-03-09-profile/docs-ref-autogen/ext/azure-iot/dt/model.yml
+++ b/2017-03-09-profile/docs-ref-autogen/ext/azure-iot/dt/model.yml
@@ -1,0 +1,181 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_model
+  name: az dt model
+  summary: Manage DTDL models and definitions on a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_model_create
+  - ext_azure-iot_az_dt_model_delete
+  - ext_azure-iot_az_dt_model_list
+  - ext_azure-iot_az_dt_model_show
+  - ext_azure-iot_az_dt_model_update
+- uid: ext_azure-iot_az_dt_model_create
+  name: az dt model create
+  summary: Uploads one or more models. When any error occurs, no models are uploaded.
+  description: --models can be inline json or file path.
+  langs:
+  - azurecli
+  examples:
+  - summary: Bulk upload all .json or .dtdl model files from a target directory. Model processing is recursive.
+    syntax:
+      content: az dt model create -n {instance_name} --from-directory {directory_path}
+  - summary: Upload model json inline or from file path.
+    syntax:
+      content: az dt model create -n {instance_name} --models {file_path_or_inline_json}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --fd --from-directory
+    summary: The directory JSON model files will be parsed from.
+    description: ''
+  - name: --models
+    summary: Inline model JSON or file path to model JSON.
+    description: ''
+- uid: ext_azure-iot_az_dt_model_delete
+  name: az dt model delete
+  summary: Delete a model. A model can only be deleted if no other models reference it.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Delete a target model.
+    syntax:
+      content: az dt model delete -n {instance_name} --dtmi "dtmi:example:Floor;1"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --dtmi --model-id -m
+    summary: 'Digital Twins model Id. Example: dtmi:example:Room;2.'
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_model_list
+  name: az dt model list
+  summary: List model metadata, definitions and dependencies.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List model metadata
+    syntax:
+      content: az dt model list -n {instance_name}
+  - summary: List model definitions
+    syntax:
+      content: az dt model list -n {instance_name} --definition
+  - summary: List dependencies of particular pre-existing model(s). Space seperate dtmi values.
+    syntax:
+      content: az dt model list -n {instance_name} --dependencies-for {model_id0} {model_id1}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --def --definition
+    parameterValueGroup: false, true
+    summary: The operation will retrieve the model definition.
+    description: ''
+  - name: --dependencies-for
+    summary: The set of models which will have their dependencies retrieved. If omitted, all models are retrieved. Format is a whitespace separated list.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_model_show
+  name: az dt model show
+  summary: Retrieve a target model or model definition.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show model meta data
+    syntax:
+      content: az dt model show -n {instance_name} --dtmi "dtmi:example:Floor;1"
+  - summary: Show model meta data and definition
+    syntax:
+      content: az dt model show -n {instance_name} --dtmi "dtmi:example:Floor;1" --definition
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --dtmi --model-id -m
+    summary: 'Digital Twins model Id. Example: dtmi:example:Room;2.'
+    description: ''
+  - name: --def --definition
+    parameterValueGroup: false, true
+    summary: The operation will retrieve the model definition.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_model_update
+  name: az dt model update
+  summary: Updates the metadata for a model. Currently a model can only be decommisioned.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Decommision a target model
+    syntax:
+      content: az dt model update -n {instance_name} --dtmi "dtmi:example:Floor;1" --decommission
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --dtmi --model-id -m
+    summary: 'Digital Twins model Id. Example: dtmi:example:Room;2.'
+    description: ''
+  - name: --decommission
+    parameterValueGroup: false, true
+    summary: Indicates intent to decommission a target model.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_model_create
+  name: az dt model create
+  summary: Uploads one or more models. When any error occurs, no models are uploaded.
+- uid: ext_azure-iot_az_dt_model_delete
+  name: az dt model delete
+  summary: Delete a model. A model can only be deleted if no other models reference it.
+- uid: ext_azure-iot_az_dt_model_list
+  name: az dt model list
+  summary: List model metadata, definitions and dependencies.
+- uid: ext_azure-iot_az_dt_model_show
+  name: az dt model show
+  summary: Retrieve a target model or model definition.
+- uid: ext_azure-iot_az_dt_model_update
+  name: az dt model update
+  summary: Updates the metadata for a model. Currently a model can only be decommisioned.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Manage DTDL models and definitions on a Digital Twins instance.

--- a/2017-03-09-profile/docs-ref-autogen/ext/azure-iot/dt/role-assignment.yml
+++ b/2017-03-09-profile/docs-ref-autogen/ext/azure-iot/dt/role-assignment.yml
@@ -1,0 +1,141 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_role_assignment
+  name: az dt role-assignment
+  summary: Manage RBAC role assignments for a Digital Twins instance.
+  description: >-
+    Note that in order to perform role assignments, the logged in principal needs permissions
+
+    such as Owner or User Access Administrator at the assigned scope.
+
+
+    This command group is provided for convenience. For more complex role assignment scenarios
+
+    use the 'az role assignment' command group.
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_role_assignment_create
+  - ext_azure-iot_az_dt_role_assignment_delete
+  - ext_azure-iot_az_dt_role_assignment_list
+- uid: ext_azure-iot_az_dt_role_assignment_create
+  name: az dt role-assignment create
+  summary: Assign a user, group or service principal to a role against a Digital Twins instance.
+  description: Note that in order to perform role assignments, the logged in principal needs permissions such as Owner or User Access Administrator at the assigned scope.
+  langs:
+  - azurecli
+  examples:
+  - summary: Assign a user (by email) the built-in Digital Twins Owner role against a target instance.
+    syntax:
+      content: az dt role-assignment create -n {instance_name} --assignee "owneruser@microsoft.com" --role "Azure Digital Twins Owner (Preview)"
+  - summary: Assign a user (by object Id) the built-in Digital Twins Reader role against a target instance.
+    syntax:
+      content: az dt role-assignment create -n {instance_name} --assignee "97a89267-0966-4054-a156-b7d86ef8e216" --role "Azure Digital Twins Reader (Preview)"
+  - summary: Assign a service principal a custom role against a target instance.
+    syntax:
+      content: az dt role-assignment create -n {instance_name} --assignee {service_principal_name_or_id} --role {role_name_or_id}
+  parameters:
+  - isRequired: true
+    name: --assignee
+    summary: 'Represent a user, group, or service principal. supported format: object id, user sign-in name, or service principal name.'
+    description: ''
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --role
+    summary: Role name or Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_role_assignment_delete
+  name: az dt role-assignment delete
+  summary: Remove a user, group or service principal role assignment from a Digital Twins instance.
+  description: Note that in order to perform role assignments, the logged in principal needs permissions such as Owner or User Access Administrator at the assigned scope.
+  langs:
+  - azurecli
+  examples:
+  - summary: Remove a user from a specific role assignment of a Digital Twins instance.
+    syntax:
+      content: az dt role-assignment delete -n {instance_name} --assignee "removeuser@microsoft.com" --role "Azure Digital Twins Reader (Preview)"
+  - summary: Remove a user from all assigned roles of a Digital Twins instance.
+    syntax:
+      content: az dt role-assignment delete -n {instance_name} --assignee "removeuser@microsoft.com"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --assignee
+    summary: 'Represent a user, group, or service principal. supported format: object id, user sign-in name, or service principal name.'
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --role
+    summary: Role name or Id.
+    description: ''
+- uid: ext_azure-iot_az_dt_role_assignment_list
+  name: az dt role-assignment list
+  summary: List the existing role assignments of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List the role assignments on a target instance.
+    syntax:
+      content: az dt role-assignment list -n {instance_name}
+  - summary: List the role assignments on a target instance and filter by role.
+    syntax:
+      content: az dt role-assignment list -n {instance_name} --role {role_name_or_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --include-inherited
+    parameterValueGroup: false, true
+    summary: Include assignments applied on parent scopes.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --role
+    summary: Role name or Id.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_role_assignment_create
+  name: az dt role-assignment create
+  summary: Assign a user, group or service principal to a role against a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_role_assignment_delete
+  name: az dt role-assignment delete
+  summary: Remove a user, group or service principal role assignment from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_role_assignment_list
+  name: az dt role-assignment list
+  summary: List the existing role assignments of a Digital Twins instance.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: >-
+  Note that in order to perform role assignments, the logged in principal needs permissions
+
+  such as Owner or User Access Administrator at the assigned scope.
+
+
+  This command group is provided for convenience. For more complex role assignment scenarios
+
+  use the 'az role assignment' command group.

--- a/2017-03-09-profile/docs-ref-autogen/ext/azure-iot/dt/route.yml
+++ b/2017-03-09-profile/docs-ref-autogen/ext/azure-iot/dt/route.yml
@@ -1,0 +1,137 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_route
+  name: az dt route
+  summary: Manage and configure event routes.
+  description: Note that an endpoint must first be configred before adding an event route.
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_route_create
+  - ext_azure-iot_az_dt_route_delete
+  - ext_azure-iot_az_dt_route_list
+  - ext_azure-iot_az_dt_route_show
+- uid: ext_azure-iot_az_dt_route_create
+  name: az dt route create
+  summary: Add an event route to a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Adds an event route for an existing endpoint on target instance with default filter of "true".
+    syntax:
+      content: az dt route create -n {instance_name} --endpoint-name {endpoint_name} --route-name {route_name}
+  - summary: Adds an event route for an existing endpoint on target instance with custom filter.
+    syntax:
+      content: az dt route create -n {instance_name} --endpoint-name {endpoint_name} --route-name {route_name} --filter "type = 'Microsoft.DigitalTwins.Twin.Create'"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - isRequired: true
+    name: --rn --route-name
+    summary: Event route name.
+    description: ''
+  - name: --filter
+    defaultValue: "true"
+    summary: Event route filter.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_route_delete
+  name: az dt route delete
+  summary: Remove an event route from a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Remove an event route from a target instance.
+    syntax:
+      content: az dt route delete -n {instance_name} --route-name {route_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --rn --route-name
+    summary: Event route name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_route_list
+  name: az dt route list
+  summary: List the configured event routes of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List configured event routes of a target instance.
+    syntax:
+      content: az dt route list -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_route_show
+  name: az dt route show
+  summary: Show details of an event route configured on a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show an event route on a target instance.
+    syntax:
+      content: az dt route show -n {instance_name} --route-name {route_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --rn --route-name
+    summary: Event route name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_route_create
+  name: az dt route create
+  summary: Add an event route to a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_delete
+  name: az dt route delete
+  summary: Remove an event route from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_list
+  name: az dt route list
+  summary: List the configured event routes of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_show
+  name: az dt route show
+  summary: Show details of an event route configured on a Digital Twins instance.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Note that an endpoint must first be configred before adding an event route.

--- a/2017-03-09-profile/docs-ref-autogen/ext/azure-iot/dt/twin.yml
+++ b/2017-03-09-profile/docs-ref-autogen/ext/azure-iot/dt/twin.yml
@@ -1,0 +1,230 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_twin
+  name: az dt twin
+  summary: Manage and configure the digital twins of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_twin_create
+  - ext_azure-iot_az_dt_twin_delete
+  - ext_azure-iot_az_dt_twin_query
+  - ext_azure-iot_az_dt_twin_show
+  - ext_azure-iot_az_dt_twin_update
+- uid: ext_azure-iot_az_dt_twin_create
+  name: az dt twin create
+  summary: Create a digital twin on an instance.
+  description: --properties can be inline JSON or file path.
+  langs:
+  - azurecli
+  examples:
+  - summary: Create a digital twin from an existing (prior-created) model.
+    syntax:
+      content: az dt twin create -n {instance_name} --dtmi urn:azureiot:DeviceManagement:DeviceInformation:1 --twin-id {twin_id}
+  - summary: Create a digital twin from an existing (prior-created) model. Instantiate with property values.
+    syntax:
+      content: "az dt twin create -n {instance_name} --dtmi urn:azureiot:DeviceManagement:DeviceInformation:1 --twin-id {twin_id} --properties '{\"manufacturer\": \"Microsoft\"}'"
+  - summary: Create a digital twin with component from existing (prior-created) models. Instantiate with property values.
+    syntax:
+      content: >-
+        az dt twin create -n {instance_name} --dtmi dtmi:example:Room;1 --twin-id {twin_id} --properties '{
+            "Temperature": 10.2,
+            "Thermostat": {
+                "$metadata": {},
+                "setPointTemp": 23.12
+            }
+        }'
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --dtmi --model-id -m
+    summary: 'Digital Twins model Id. Example: dtmi:example:Room;2.'
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --properties -p
+    summary: Initial property values for instantiating a digital twin or related components. Provide file path or inline JSON.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_delete
+  name: az dt twin delete
+  summary: Remove a digital twin. All relationships referencing this twin must already be deleted.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Remove a digital twin by Id.
+    syntax:
+      content: az dt twin delete -n {instance_name} --twin-id {twin_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_query
+  name: az dt twin query
+  summary: Query the digital twins of an instance. Allows traversing relationships and filtering by property values.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Query all digital twins in target instance and project all attributes. Also show cost in query units.
+    syntax:
+      content: az dt twin query -n {instance_name} -q "select * from digitaltwins" --show-cost
+  - summary: Query by model and project all attributes.
+    syntax:
+      content: az dt twin query -n {instance_name} -q "select * from digitaltwins T where IS_OF_MODEL(T, 'dtmi:example:Room;2')"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --query-command -q
+    summary: User query to be executed.
+    description: ''
+  - name: --cost --show-cost
+    parameterValueGroup: false, true
+    summary: Calculates and shows the query charge.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_show
+  name: az dt twin show
+  summary: Show the details of a digital twin.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show the details of a digital twin.
+    syntax:
+      content: az dt twin show -n {instance_name} --twin-id {twin_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_update
+  name: az dt twin update
+  summary: Update an instance digital twin via JSON patch specification.
+  description: Updates to property values and $model elements may happen in the same request. Operations are limited to add, replace and remove.
+  langs:
+  - azurecli
+  examples:
+  - summary: Update a digital twin via JSON patch specification.
+    syntax:
+      content: "az dt twin update -n {instance_name} --twin-id {twin_id} --json-patch '{\"op\":\"replace\", \"path\":\"/Temperature\", \"value\": 20.5}'"
+  - summary: Update a digital twin via JSON patch specification.
+    syntax:
+      content: >-
+        az dt twin update -n {instance_name} --twin-id {twin_id} --json-patch '[
+          {"op":"replace", "path":"/Temperature", "value": 20.5},
+          {"op":"add", "path":"/Areas", "value": ["ControlSystem"]}
+        ]'
+  - summary: Update a digital twin via JSON patch specification defined in a file.
+    syntax:
+      content: az dt twin update -n {instance_name} --twin-id {twin_id} --json-patch ./my/patch/document.json
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --json-patch --patch
+    summary: An update specification described by JSON-patch. Updates to property values and $model elements may happen in the same request. Operations are limited to add, replace and remove. Provide file path or inline JSON.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_twin_component
+  name: az dt twin component
+  summary: Show and update the digital twin components of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_component_show
+  name: az dt twin component show
+  summary: Show details of a digital twin component.
+- uid: ext_azure-iot_az_dt_twin_component_update
+  name: az dt twin component update
+  summary: Update a digital twin component via JSON patch specification.
+- uid: ext_azure-iot_az_dt_twin_create
+  name: az dt twin create
+  summary: Create a digital twin on an instance.
+- uid: ext_azure-iot_az_dt_twin_delete
+  name: az dt twin delete
+  summary: Remove a digital twin. All relationships referencing this twin must already be deleted.
+- uid: ext_azure-iot_az_dt_twin_query
+  name: az dt twin query
+  summary: Query the digital twins of an instance. Allows traversing relationships and filtering by property values.
+- uid: ext_azure-iot_az_dt_twin_relationship
+  name: az dt twin relationship
+  summary: Manage and configure the digital twin relationships of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_relationship_create
+  name: az dt twin relationship create
+  summary: Create a relationship between source and target digital twins.
+- uid: ext_azure-iot_az_dt_twin_relationship_delete
+  name: az dt twin relationship delete
+  summary: Delete a digital twin relationship on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_relationship_list
+  name: az dt twin relationship list
+  summary: List the relationships of a digital twin.
+- uid: ext_azure-iot_az_dt_twin_relationship_show
+  name: az dt twin relationship show
+  summary: Show details of a digital twin relationship.
+- uid: ext_azure-iot_az_dt_twin_relationship_update
+  name: az dt twin relationship update
+  summary: Updates the properties of a relationship between two digital twins via JSON patch specification.
+- uid: ext_azure-iot_az_dt_twin_show
+  name: az dt twin show
+  summary: Show the details of a digital twin.
+- uid: ext_azure-iot_az_dt_twin_telemetry
+  name: az dt twin telemetry
+  summary: Test and validate the event routes and endpoints of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_telemetry_send
+  name: az dt twin telemetry send
+  summary: Sends telemetry on behalf of a digital twin. If component path is provided the emitted telemetry is on behalf of the component.
+- uid: ext_azure-iot_az_dt_twin_update
+  name: az dt twin update
+  summary: Update an instance digital twin via JSON patch specification.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Manage and configure the digital twins of a Digital Twins instance.

--- a/2017-03-09-profile/docs-ref-autogen/ext/azure-iot/dt/twin/component.yml
+++ b/2017-03-09-profile/docs-ref-autogen/ext/azure-iot/dt/twin/component.yml
@@ -1,0 +1,100 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_twin_component
+  name: az dt twin component
+  summary: Show and update the digital twin components of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_twin_component_show
+  - ext_azure-iot_az_dt_twin_component_update
+- uid: ext_azure-iot_az_dt_twin_component_show
+  name: az dt twin component show
+  summary: Show details of a digital twin component.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show details of a digital twin component
+    syntax:
+      content: az dt twin component show -n {instance_name} --twin-id {twin_id} --component Thermostat
+  parameters:
+  - isRequired: true
+    name: --component
+    summary: The path to the DTDL component.
+    description: ''
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_component_update
+  name: az dt twin component update
+  summary: Update a digital twin component via JSON patch specification.
+  description: Updates to property values and $model elements may happen in the same request. Operations are limited to add, replace and remove.
+  langs:
+  - azurecli
+  examples:
+  - summary: Update a digital twin component via JSON patch specification.
+    syntax:
+      content: "az dt twin component update -n {instance_name} --twin-id {twin_id} --component {component_path} --json-patch '{\"op\":\"replace\", \"path\":\"/Temperature\", \"value\": 20.5}'"
+  - summary: Update a digital twin component via JSON patch specification.
+    syntax:
+      content: >-
+        az dt twin component update -n {instance_name} --twin-id {twin_id} --component {component_path} --json-patch '[
+          {"op":"replace", "path":"/Temperature", "value": 20.5},
+          {"op":"add", "path":"/Areas", "value": ["ControlSystem"]}
+        ]'
+  - summary: Update a digital twin component via JSON patch specification defined in a file.
+    syntax:
+      content: az dt twin component update -n {instance_name} --twin-id {twin_id} --component {component_path} --json-patch ./my/patch/document.json
+  parameters:
+  - isRequired: true
+    name: --component
+    summary: The path to the DTDL component.
+    description: ''
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --json-patch --patch
+    summary: An update specification described by JSON-patch. Updates to property values and $model elements may happen in the same request. Operations are limited to add, replace and remove. Provide file path or inline JSON.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_twin_component_show
+  name: az dt twin component show
+  summary: Show details of a digital twin component.
+- uid: ext_azure-iot_az_dt_twin_component_update
+  name: az dt twin component update
+  summary: Update a digital twin component via JSON patch specification.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Show and update the digital twin components of a Digital Twins instance.

--- a/2017-03-09-profile/docs-ref-autogen/ext/azure-iot/dt/twin/relationship.yml
+++ b/2017-03-09-profile/docs-ref-autogen/ext/azure-iot/dt/twin/relationship.yml
@@ -1,0 +1,216 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_twin_relationship
+  name: az dt twin relationship
+  summary: Manage and configure the digital twin relationships of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_twin_relationship_create
+  - ext_azure-iot_az_dt_twin_relationship_delete
+  - ext_azure-iot_az_dt_twin_relationship_list
+  - ext_azure-iot_az_dt_twin_relationship_show
+  - ext_azure-iot_az_dt_twin_relationship_update
+- uid: ext_azure-iot_az_dt_twin_relationship_create
+  name: az dt twin relationship create
+  summary: Create a relationship between source and target digital twins.
+  description: --properties can be inline JSON or file path.
+  langs:
+  - azurecli
+  examples:
+  - summary: Create a relationship between two digital twins.
+    syntax:
+      content: az dt twin relationship create -n {instance_name} --relationship-id {relationship_id} --relationship contains --source {source_twin_id} --target {target_twin_id}
+  - summary: Create a relationship with initialized properties between two digital twins.
+    syntax:
+      content: "az dt twin relationship create -n {instance_name} --relationship-id {relationship_id} --relationship contains --source {source_twin_id} --target {target_twin_id} --properties '{\"ownershipUser\": \"me\", \"ownershipDepartment\": \"Computer Science\"}'"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --kind --relationship
+    summary: "Relationship name or kind. For example: 'contains'."
+    description: ''
+  - isRequired: true
+    name: --relationship-id -r
+    summary: Relationship Id.
+    description: ''
+  - isRequired: true
+    name: --source --source-twin-id -s
+    summary: The source twin Id for a relationship.
+    description: ''
+  - isRequired: true
+    name: --target --target-twin-id -t
+    summary: The target twin Id for a relationship.
+    description: ''
+  - name: --properties -p
+    summary: Initial property values for instantiating a digital twin relationship. Provide file path or inline JSON.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_relationship_delete
+  name: az dt twin relationship delete
+  summary: Delete a digital twin relationship on a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Delete a digital twin relationship.
+    syntax:
+      content: az dt twin relationship delete -n {instance_name} --twin-id {twin_id} --relationship-id {relationship_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --relationship-id -r
+    summary: Relationship Id.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_relationship_list
+  name: az dt twin relationship list
+  summary: List the relationships of a digital twin.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List outgoing relationships of a digital twin.
+    syntax:
+      content: az dt twin relationship list -n {instance_name} --twin-id {twin_id}
+  - summary: List outgoing relationships of a digital twin and filter on relationship 'contains'
+    syntax:
+      content: az dt twin relationship list -n {instance_name} --twin-id {twin_id} --relationship contains
+  - summary: List incoming relationships of a digital twin.
+    syntax:
+      content: az dt twin relationship list -n {instance_name} --twin-id {twin_id} --incoming
+  - summary: List incoming relationships of a digital twin and filter on relationship 'contains'.
+    syntax:
+      content: az dt twin relationship list -n {instance_name} --twin-id {twin_id} --relationship contains --incoming
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --incoming
+    parameterValueGroup: false, true
+    summary: Retrieves all incoming relationships for a digital twin.
+    description: ''
+  - name: --kind --relationship
+    summary: Filter result by the kind of relationship.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_relationship_show
+  name: az dt twin relationship show
+  summary: Show details of a digital twin relationship.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show details of a digital twin relationship.
+    syntax:
+      content: az dt twin relationship show -n {instance_name} --twin-id {twin_id} --relationship-id {relationship_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --relationship-id -r
+    summary: Relationship Id.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_relationship_update
+  name: az dt twin relationship update
+  summary: Updates the properties of a relationship between two digital twins via JSON patch specification.
+  description: Operations are limited to add, replace and remove.
+  langs:
+  - azurecli
+  examples:
+  - summary: Update a digital twin relationship via JSON patch specification.
+    syntax:
+      content: "az dt twin relationship update -n {instance_name} --twin-id {twin_id} --relationship-id {relationship_id} --relationship contains --json-patch '{\"op\":\"replace\", \"path\":\"/Temperature\", \"value\": 20.5}'"
+  - summary: Update a digital twin relationship via JSON patch specification.
+    syntax:
+      content: >-
+        az dt twin relationship update -n {instance_name} --twin-id {twin_id} --relationship-id {relationship_id} --relationship contains --json-patch '[
+          {"op":"replace", "path":"/Temperature", "value": 20.5},
+          {"op":"add", "path":"/Areas", "value": ["ControlSystem"]}
+        ]'
+  - summary: Update a digital twin relationship via JSON patch specification defined in a file.
+    syntax:
+      content: az dt twin relationship update -n {instance_name} --twin-id {twin_id} --relationship-id {relationship_id} --relationship contains --json-patch ./my/patch/document.json
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --json-patch --patch
+    summary: An update specification described by JSON-patch. Updates to property values and $model elements may happen in the same request. Operations are limited to add, replace and remove. Provide file path or inline JSON.
+    description: ''
+  - isRequired: true
+    name: --relationship-id -r
+    summary: Relationship Id.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_twin_relationship_create
+  name: az dt twin relationship create
+  summary: Create a relationship between source and target digital twins.
+- uid: ext_azure-iot_az_dt_twin_relationship_delete
+  name: az dt twin relationship delete
+  summary: Delete a digital twin relationship on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_relationship_list
+  name: az dt twin relationship list
+  summary: List the relationships of a digital twin.
+- uid: ext_azure-iot_az_dt_twin_relationship_show
+  name: az dt twin relationship show
+  summary: Show details of a digital twin relationship.
+- uid: ext_azure-iot_az_dt_twin_relationship_update
+  name: az dt twin relationship update
+  summary: Updates the properties of a relationship between two digital twins via JSON patch specification.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Manage and configure the digital twin relationships of a Digital Twins instance.

--- a/2017-03-09-profile/docs-ref-autogen/ext/azure-iot/dt/twin/telemetry.yml
+++ b/2017-03-09-profile/docs-ref-autogen/ext/azure-iot/dt/twin/telemetry.yml
@@ -1,0 +1,61 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_twin_telemetry
+  name: az dt twin telemetry
+  summary: Test and validate the event routes and endpoints of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_twin_telemetry_send
+- uid: ext_azure-iot_az_dt_twin_telemetry_send
+  name: az dt twin telemetry send
+  summary: Sends telemetry on behalf of a digital twin. If component path is provided the emitted telemetry is on behalf of the component.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Send twin telemetry
+    syntax:
+      content: az dt twin telemetry send -n {instance_name} --twin-id {twin_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --component
+    summary: The path to the DTDL component. If set, telemetry will be emitted on behalf of the component.
+    description: ''
+  - name: --dt-id
+    summary: A unique message identifier (in the scope of the digital twin id) that is commonly used for de-duplicating messages. If no value is provided a GUID is automatically generated.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --telemetry
+    summary: 'Inline telemetry JSON or file path to telemetry JSON. Default payload is an empty object: {}.'
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_twin_telemetry_send
+  name: az dt twin telemetry send
+  summary: Sends telemetry on behalf of a digital twin. If component path is provided the emitted telemetry is on behalf of the component.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Test and validate the event routes and endpoints of a Digital Twins instance.

--- a/2017-03-09-profile/docs-ref-autogen/ext/azure-iot/index.yml
+++ b/2017-03-09-profile/docs-ref-autogen/ext/azure-iot/index.yml
@@ -8,6 +8,9 @@ items:
   - azurecli
   children: []
 commands:
+- uid: ext_azure-iot_az_dt
+  name: az dt
+  summary: Manage Azure Digital Twins (ADT) solutions & infrastructure.
 - uid: ext_azure-iot_az_iot
   name: az iot
   summary: Manage Internet of Things (IoT) assets. Augmented with the IoT extension.

--- a/2018-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt.yml
+++ b/2018-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt.yml
@@ -1,0 +1,253 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt
+  name: az dt
+  summary: Manage Azure Digital Twins (ADT) solutions & infrastructure.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_create
+  - ext_azure-iot_az_dt_delete
+  - ext_azure-iot_az_dt_list
+  - ext_azure-iot_az_dt_show
+- uid: ext_azure-iot_az_dt_create
+  name: az dt create
+  summary: Create a new Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Create instance in target resource group with default location.
+    syntax:
+      content: az dt create -n {instance_name} -g {resouce_group} -l eastus2euap
+  - summary: Create instance in target resource group with specified location and tags.
+    syntax:
+      content: az dt create -n {instance_name} -g {resouce_group} -l westcentralus --tags "a=b;c=d"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --location -l
+    summary: Digital Twins instance location. You can configure the default location using `az configure --defaults location=&lt;name&gt;`.
+    description: ''
+  - isRequired: true
+    name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --tags
+    summary: 'Digital Twins instance tags. Property bag in key-value pairs with the following format: a=b;c=d.'
+    description: ''
+- uid: ext_azure-iot_az_dt_delete
+  name: az dt delete
+  summary: Delete an existing Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Delete an arbitrary instance.
+    syntax:
+      content: az dt delete -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_list
+  name: az dt list
+  summary: List the collection of Digital Twins instances by subscription or resource group.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List all instances in the current subscription.
+    syntax:
+      content: az dt list
+  - summary: List all instances in target resource group and output in table format.
+    syntax:
+      content: az dt list -g {resource_group} --output table
+  - summary: List all instances in subscription that meet a condition.
+    syntax:
+      content: az dt list --query "[?contains(name, 'Production')]"
+  - summary: Count instances that meet condition.
+    syntax:
+      content: az dt list --query "length([?contains(name, 'Production')])"
+  parameters:
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_show
+  name: az dt show
+  summary: Show an existing Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show an instance.
+    syntax:
+      content: az dt show -n {instance_name}
+  - summary: Show an instance and project certain properties.
+    syntax:
+      content: az dt show -n {instance_name} --query "{Endpoint:hostName, Location:location}"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_create
+  name: az dt create
+  summary: Create a new Digital Twins instance.
+- uid: ext_azure-iot_az_dt_delete
+  name: az dt delete
+  summary: Delete an existing Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint
+  name: az dt endpoint
+  summary: Manage and configure Digital Twins instance endpoints.
+- uid: ext_azure-iot_az_dt_endpoint_create
+  name: az dt endpoint create
+  summary: Add egress endpoints to a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_create_eventgrid
+  name: az dt endpoint create eventgrid
+  summary: Adds an EventGrid Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_eventhub
+  name: az dt endpoint create eventhub
+  summary: Adds an EventHub endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_servicebus
+  name: az dt endpoint create servicebus
+  summary: Adds a ServiceBus Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_delete
+  name: az dt endpoint delete
+  summary: Remove an endpoint from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_list
+  name: az dt endpoint list
+  summary: List all egress endpoints configured on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_show
+  name: az dt endpoint show
+  summary: Show details of an endpoint configured on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_list
+  name: az dt list
+  summary: List the collection of Digital Twins instances by subscription or resource group.
+- uid: ext_azure-iot_az_dt_model
+  name: az dt model
+  summary: Manage DTDL models and definitions on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_model_create
+  name: az dt model create
+  summary: Uploads one or more models. When any error occurs, no models are uploaded.
+- uid: ext_azure-iot_az_dt_model_delete
+  name: az dt model delete
+  summary: Delete a model. A model can only be deleted if no other models reference it.
+- uid: ext_azure-iot_az_dt_model_list
+  name: az dt model list
+  summary: List model metadata, definitions and dependencies.
+- uid: ext_azure-iot_az_dt_model_show
+  name: az dt model show
+  summary: Retrieve a target model or model definition.
+- uid: ext_azure-iot_az_dt_model_update
+  name: az dt model update
+  summary: Updates the metadata for a model. Currently a model can only be decommisioned.
+- uid: ext_azure-iot_az_dt_role_assignment
+  name: az dt role-assignment
+  summary: Manage RBAC role assignments for a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_role_assignment_create
+  name: az dt role-assignment create
+  summary: Assign a user, group or service principal to a role against a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_role_assignment_delete
+  name: az dt role-assignment delete
+  summary: Remove a user, group or service principal role assignment from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_role_assignment_list
+  name: az dt role-assignment list
+  summary: List the existing role assignments of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route
+  name: az dt route
+  summary: Manage and configure event routes.
+- uid: ext_azure-iot_az_dt_route_create
+  name: az dt route create
+  summary: Add an event route to a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_delete
+  name: az dt route delete
+  summary: Remove an event route from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_list
+  name: az dt route list
+  summary: List the configured event routes of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_show
+  name: az dt route show
+  summary: Show details of an event route configured on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_show
+  name: az dt show
+  summary: Show an existing Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin
+  name: az dt twin
+  summary: Manage and configure the digital twins of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_component
+  name: az dt twin component
+  summary: Show and update the digital twin components of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_component_show
+  name: az dt twin component show
+  summary: Show details of a digital twin component.
+- uid: ext_azure-iot_az_dt_twin_component_update
+  name: az dt twin component update
+  summary: Update a digital twin component via JSON patch specification.
+- uid: ext_azure-iot_az_dt_twin_create
+  name: az dt twin create
+  summary: Create a digital twin on an instance.
+- uid: ext_azure-iot_az_dt_twin_delete
+  name: az dt twin delete
+  summary: Remove a digital twin. All relationships referencing this twin must already be deleted.
+- uid: ext_azure-iot_az_dt_twin_query
+  name: az dt twin query
+  summary: Query the digital twins of an instance. Allows traversing relationships and filtering by property values.
+- uid: ext_azure-iot_az_dt_twin_relationship
+  name: az dt twin relationship
+  summary: Manage and configure the digital twin relationships of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_relationship_create
+  name: az dt twin relationship create
+  summary: Create a relationship between source and target digital twins.
+- uid: ext_azure-iot_az_dt_twin_relationship_delete
+  name: az dt twin relationship delete
+  summary: Delete a digital twin relationship on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_relationship_list
+  name: az dt twin relationship list
+  summary: List the relationships of a digital twin.
+- uid: ext_azure-iot_az_dt_twin_relationship_show
+  name: az dt twin relationship show
+  summary: Show details of a digital twin relationship.
+- uid: ext_azure-iot_az_dt_twin_relationship_update
+  name: az dt twin relationship update
+  summary: Updates the properties of a relationship between two digital twins via JSON patch specification.
+- uid: ext_azure-iot_az_dt_twin_show
+  name: az dt twin show
+  summary: Show the details of a digital twin.
+- uid: ext_azure-iot_az_dt_twin_telemetry
+  name: az dt twin telemetry
+  summary: Test and validate the event routes and endpoints of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_telemetry_send
+  name: az dt twin telemetry send
+  summary: Sends telemetry on behalf of a digital twin. If component path is provided the emitted telemetry is on behalf of the component.
+- uid: ext_azure-iot_az_dt_twin_update
+  name: az dt twin update
+  summary: Update an instance digital twin via JSON patch specification.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Manage Azure Digital Twins (ADT) solutions & infrastructure.

--- a/2018-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/endpoint.yml
+++ b/2018-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/endpoint.yml
@@ -1,0 +1,112 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_endpoint
+  name: az dt endpoint
+  summary: Manage and configure Digital Twins instance endpoints.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_endpoint_delete
+  - ext_azure-iot_az_dt_endpoint_list
+  - ext_azure-iot_az_dt_endpoint_show
+- uid: ext_azure-iot_az_dt_endpoint_delete
+  name: az dt endpoint delete
+  summary: Remove an endpoint from a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Remove an endpoint from an instance.
+    syntax:
+      content: az dt endpoint delete -n {instance_name} --endpoint-name {endpoint_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_endpoint_list
+  name: az dt endpoint list
+  summary: List all egress endpoints configured on a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List all egress endpoints configured on an instance.
+    syntax:
+      content: az dt endpoint list -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_endpoint_show
+  name: az dt endpoint show
+  summary: Show details of an endpoint configured on a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show a desired endpoint by name on an instance.
+    syntax:
+      content: az dt endpoint show -n {instance_name} --endpoint-name {endpoint_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_endpoint_create
+  name: az dt endpoint create
+  summary: Add egress endpoints to a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_create_eventgrid
+  name: az dt endpoint create eventgrid
+  summary: Adds an EventGrid Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_eventhub
+  name: az dt endpoint create eventhub
+  summary: Adds an EventHub endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_servicebus
+  name: az dt endpoint create servicebus
+  summary: Adds a ServiceBus Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_delete
+  name: az dt endpoint delete
+  summary: Remove an endpoint from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_list
+  name: az dt endpoint list
+  summary: List all egress endpoints configured on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_show
+  name: az dt endpoint show
+  summary: Show details of an endpoint configured on a Digital Twins instance.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Manage and configure Digital Twins instance endpoints.

--- a/2018-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/endpoint/create.yml
+++ b/2018-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/endpoint/create.yml
@@ -1,0 +1,153 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_endpoint_create
+  name: az dt endpoint create
+  summary: Add egress endpoints to a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_endpoint_create_eventgrid
+  - ext_azure-iot_az_dt_endpoint_create_eventhub
+  - ext_azure-iot_az_dt_endpoint_create_servicebus
+- uid: ext_azure-iot_az_dt_endpoint_create_eventgrid
+  name: az dt endpoint create eventgrid
+  summary: Adds an EventGrid Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Adds an EventGrid Topic endpoint to a target instance.
+    syntax:
+      content: az dt endpoint create eventgrid --endpoint-name {endpoint_name} --eventgrid-resource-group {eventgrid_resource_group} --eventgrid-topic {eventgrid_topic_name} -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --tags
+    summary: 'Digital Twins endpoint tags. Property bag in key-value pairs with the following format: a=b;c=d.'
+    description: ''
+  - isRequired: true
+    name: --egg --eventgrid-resource-group
+    summary: Name of EventGrid Topic resource group.
+    description: ''
+  - isRequired: true
+    name: --egt --eventgrid-topic
+    summary: Name of EventGrid Topic to integrate with.
+    description: ''
+- uid: ext_azure-iot_az_dt_endpoint_create_eventhub
+  name: az dt endpoint create eventhub
+  summary: Adds an EventHub endpoint to a Digital Twins instance. Requires pre-created resource.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Adds an EventHub endpoint to a target instance.
+    syntax:
+      content: az dt endpoint create eventhub --endpoint-name {endpoint_name} --eventhub-resource-group {eventhub_resource_group} --eventhub-namespace {eventhub_namespace} --eventhub {eventhub_name} --eventhub-policy {eventhub_policy} -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --tags
+    summary: 'Digital Twins endpoint tags. Property bag in key-value pairs with the following format: a=b;c=d.'
+    description: ''
+  - isRequired: true
+    name: --eh --eventhub
+    summary: Name of EventHub to integrate with.
+    description: ''
+  - isRequired: true
+    name: --ehg --eventhub-resource-group
+    summary: Name of EventHub resource group.
+    description: ''
+  - isRequired: true
+    name: --ehn --eventhub-namespace
+    summary: EventHub Namespace identifier.
+    description: ''
+  - isRequired: true
+    name: --ehp --eventhub-policy
+    summary: EventHub policy to use for endpoint configuration.
+    description: ''
+- uid: ext_azure-iot_az_dt_endpoint_create_servicebus
+  name: az dt endpoint create servicebus
+  summary: Adds a ServiceBus Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Adds a ServiceBus Topic endpoint to a target instance.
+    syntax:
+      content: az dt endpoint create servicebus --endpoint-name {endpoint_name} --servicebus-resource-group {servicebus_resource_group} --servicebus-namespace {servicebus_namespace} --servicebus-topic {servicebus_topic_name} --servicebus-policy {servicebus_policy} -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --tags
+    summary: 'Digital Twins endpoint tags. Property bag in key-value pairs with the following format: a=b;c=d.'
+    description: ''
+  - isRequired: true
+    name: --sbg --servicebus-resource-group
+    summary: Name of ServiceBus resource group.
+    description: ''
+  - isRequired: true
+    name: --sbn --servicebus-namespace
+    summary: ServiceBus Namespace identifier.
+    description: ''
+  - isRequired: true
+    name: --sbp --servicebus-policy
+    summary: ServiceBus Topic policy to use for endpoint configuration.
+    description: ''
+  - isRequired: true
+    name: --sbt --servicebus-topic
+    summary: Name of ServiceBus Topic to integrate with.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_endpoint_create_eventgrid
+  name: az dt endpoint create eventgrid
+  summary: Adds an EventGrid Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_eventhub
+  name: az dt endpoint create eventhub
+  summary: Adds an EventHub endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_servicebus
+  name: az dt endpoint create servicebus
+  summary: Adds a ServiceBus Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Add egress endpoints to a Digital Twins instance.

--- a/2018-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/model.yml
+++ b/2018-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/model.yml
@@ -1,0 +1,181 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_model
+  name: az dt model
+  summary: Manage DTDL models and definitions on a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_model_create
+  - ext_azure-iot_az_dt_model_delete
+  - ext_azure-iot_az_dt_model_list
+  - ext_azure-iot_az_dt_model_show
+  - ext_azure-iot_az_dt_model_update
+- uid: ext_azure-iot_az_dt_model_create
+  name: az dt model create
+  summary: Uploads one or more models. When any error occurs, no models are uploaded.
+  description: --models can be inline json or file path.
+  langs:
+  - azurecli
+  examples:
+  - summary: Bulk upload all .json or .dtdl model files from a target directory. Model processing is recursive.
+    syntax:
+      content: az dt model create -n {instance_name} --from-directory {directory_path}
+  - summary: Upload model json inline or from file path.
+    syntax:
+      content: az dt model create -n {instance_name} --models {file_path_or_inline_json}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --fd --from-directory
+    summary: The directory JSON model files will be parsed from.
+    description: ''
+  - name: --models
+    summary: Inline model JSON or file path to model JSON.
+    description: ''
+- uid: ext_azure-iot_az_dt_model_delete
+  name: az dt model delete
+  summary: Delete a model. A model can only be deleted if no other models reference it.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Delete a target model.
+    syntax:
+      content: az dt model delete -n {instance_name} --dtmi "dtmi:example:Floor;1"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --dtmi --model-id -m
+    summary: 'Digital Twins model Id. Example: dtmi:example:Room;2.'
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_model_list
+  name: az dt model list
+  summary: List model metadata, definitions and dependencies.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List model metadata
+    syntax:
+      content: az dt model list -n {instance_name}
+  - summary: List model definitions
+    syntax:
+      content: az dt model list -n {instance_name} --definition
+  - summary: List dependencies of particular pre-existing model(s). Space seperate dtmi values.
+    syntax:
+      content: az dt model list -n {instance_name} --dependencies-for {model_id0} {model_id1}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --def --definition
+    parameterValueGroup: false, true
+    summary: The operation will retrieve the model definition.
+    description: ''
+  - name: --dependencies-for
+    summary: The set of models which will have their dependencies retrieved. If omitted, all models are retrieved. Format is a whitespace separated list.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_model_show
+  name: az dt model show
+  summary: Retrieve a target model or model definition.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show model meta data
+    syntax:
+      content: az dt model show -n {instance_name} --dtmi "dtmi:example:Floor;1"
+  - summary: Show model meta data and definition
+    syntax:
+      content: az dt model show -n {instance_name} --dtmi "dtmi:example:Floor;1" --definition
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --dtmi --model-id -m
+    summary: 'Digital Twins model Id. Example: dtmi:example:Room;2.'
+    description: ''
+  - name: --def --definition
+    parameterValueGroup: false, true
+    summary: The operation will retrieve the model definition.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_model_update
+  name: az dt model update
+  summary: Updates the metadata for a model. Currently a model can only be decommisioned.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Decommision a target model
+    syntax:
+      content: az dt model update -n {instance_name} --dtmi "dtmi:example:Floor;1" --decommission
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --dtmi --model-id -m
+    summary: 'Digital Twins model Id. Example: dtmi:example:Room;2.'
+    description: ''
+  - name: --decommission
+    parameterValueGroup: false, true
+    summary: Indicates intent to decommission a target model.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_model_create
+  name: az dt model create
+  summary: Uploads one or more models. When any error occurs, no models are uploaded.
+- uid: ext_azure-iot_az_dt_model_delete
+  name: az dt model delete
+  summary: Delete a model. A model can only be deleted if no other models reference it.
+- uid: ext_azure-iot_az_dt_model_list
+  name: az dt model list
+  summary: List model metadata, definitions and dependencies.
+- uid: ext_azure-iot_az_dt_model_show
+  name: az dt model show
+  summary: Retrieve a target model or model definition.
+- uid: ext_azure-iot_az_dt_model_update
+  name: az dt model update
+  summary: Updates the metadata for a model. Currently a model can only be decommisioned.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Manage DTDL models and definitions on a Digital Twins instance.

--- a/2018-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/role-assignment.yml
+++ b/2018-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/role-assignment.yml
@@ -1,0 +1,141 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_role_assignment
+  name: az dt role-assignment
+  summary: Manage RBAC role assignments for a Digital Twins instance.
+  description: >-
+    Note that in order to perform role assignments, the logged in principal needs permissions
+
+    such as Owner or User Access Administrator at the assigned scope.
+
+
+    This command group is provided for convenience. For more complex role assignment scenarios
+
+    use the 'az role assignment' command group.
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_role_assignment_create
+  - ext_azure-iot_az_dt_role_assignment_delete
+  - ext_azure-iot_az_dt_role_assignment_list
+- uid: ext_azure-iot_az_dt_role_assignment_create
+  name: az dt role-assignment create
+  summary: Assign a user, group or service principal to a role against a Digital Twins instance.
+  description: Note that in order to perform role assignments, the logged in principal needs permissions such as Owner or User Access Administrator at the assigned scope.
+  langs:
+  - azurecli
+  examples:
+  - summary: Assign a user (by email) the built-in Digital Twins Owner role against a target instance.
+    syntax:
+      content: az dt role-assignment create -n {instance_name} --assignee "owneruser@microsoft.com" --role "Azure Digital Twins Owner (Preview)"
+  - summary: Assign a user (by object Id) the built-in Digital Twins Reader role against a target instance.
+    syntax:
+      content: az dt role-assignment create -n {instance_name} --assignee "97a89267-0966-4054-a156-b7d86ef8e216" --role "Azure Digital Twins Reader (Preview)"
+  - summary: Assign a service principal a custom role against a target instance.
+    syntax:
+      content: az dt role-assignment create -n {instance_name} --assignee {service_principal_name_or_id} --role {role_name_or_id}
+  parameters:
+  - isRequired: true
+    name: --assignee
+    summary: 'Represent a user, group, or service principal. supported format: object id, user sign-in name, or service principal name.'
+    description: ''
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --role
+    summary: Role name or Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_role_assignment_delete
+  name: az dt role-assignment delete
+  summary: Remove a user, group or service principal role assignment from a Digital Twins instance.
+  description: Note that in order to perform role assignments, the logged in principal needs permissions such as Owner or User Access Administrator at the assigned scope.
+  langs:
+  - azurecli
+  examples:
+  - summary: Remove a user from a specific role assignment of a Digital Twins instance.
+    syntax:
+      content: az dt role-assignment delete -n {instance_name} --assignee "removeuser@microsoft.com" --role "Azure Digital Twins Reader (Preview)"
+  - summary: Remove a user from all assigned roles of a Digital Twins instance.
+    syntax:
+      content: az dt role-assignment delete -n {instance_name} --assignee "removeuser@microsoft.com"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --assignee
+    summary: 'Represent a user, group, or service principal. supported format: object id, user sign-in name, or service principal name.'
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --role
+    summary: Role name or Id.
+    description: ''
+- uid: ext_azure-iot_az_dt_role_assignment_list
+  name: az dt role-assignment list
+  summary: List the existing role assignments of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List the role assignments on a target instance.
+    syntax:
+      content: az dt role-assignment list -n {instance_name}
+  - summary: List the role assignments on a target instance and filter by role.
+    syntax:
+      content: az dt role-assignment list -n {instance_name} --role {role_name_or_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --include-inherited
+    parameterValueGroup: false, true
+    summary: Include assignments applied on parent scopes.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --role
+    summary: Role name or Id.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_role_assignment_create
+  name: az dt role-assignment create
+  summary: Assign a user, group or service principal to a role against a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_role_assignment_delete
+  name: az dt role-assignment delete
+  summary: Remove a user, group or service principal role assignment from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_role_assignment_list
+  name: az dt role-assignment list
+  summary: List the existing role assignments of a Digital Twins instance.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: >-
+  Note that in order to perform role assignments, the logged in principal needs permissions
+
+  such as Owner or User Access Administrator at the assigned scope.
+
+
+  This command group is provided for convenience. For more complex role assignment scenarios
+
+  use the 'az role assignment' command group.

--- a/2018-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/route.yml
+++ b/2018-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/route.yml
@@ -1,0 +1,137 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_route
+  name: az dt route
+  summary: Manage and configure event routes.
+  description: Note that an endpoint must first be configred before adding an event route.
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_route_create
+  - ext_azure-iot_az_dt_route_delete
+  - ext_azure-iot_az_dt_route_list
+  - ext_azure-iot_az_dt_route_show
+- uid: ext_azure-iot_az_dt_route_create
+  name: az dt route create
+  summary: Add an event route to a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Adds an event route for an existing endpoint on target instance with default filter of "true".
+    syntax:
+      content: az dt route create -n {instance_name} --endpoint-name {endpoint_name} --route-name {route_name}
+  - summary: Adds an event route for an existing endpoint on target instance with custom filter.
+    syntax:
+      content: az dt route create -n {instance_name} --endpoint-name {endpoint_name} --route-name {route_name} --filter "type = 'Microsoft.DigitalTwins.Twin.Create'"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - isRequired: true
+    name: --rn --route-name
+    summary: Event route name.
+    description: ''
+  - name: --filter
+    defaultValue: "true"
+    summary: Event route filter.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_route_delete
+  name: az dt route delete
+  summary: Remove an event route from a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Remove an event route from a target instance.
+    syntax:
+      content: az dt route delete -n {instance_name} --route-name {route_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --rn --route-name
+    summary: Event route name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_route_list
+  name: az dt route list
+  summary: List the configured event routes of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List configured event routes of a target instance.
+    syntax:
+      content: az dt route list -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_route_show
+  name: az dt route show
+  summary: Show details of an event route configured on a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show an event route on a target instance.
+    syntax:
+      content: az dt route show -n {instance_name} --route-name {route_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --rn --route-name
+    summary: Event route name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_route_create
+  name: az dt route create
+  summary: Add an event route to a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_delete
+  name: az dt route delete
+  summary: Remove an event route from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_list
+  name: az dt route list
+  summary: List the configured event routes of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_show
+  name: az dt route show
+  summary: Show details of an event route configured on a Digital Twins instance.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Note that an endpoint must first be configred before adding an event route.

--- a/2018-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/twin.yml
+++ b/2018-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/twin.yml
@@ -1,0 +1,230 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_twin
+  name: az dt twin
+  summary: Manage and configure the digital twins of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_twin_create
+  - ext_azure-iot_az_dt_twin_delete
+  - ext_azure-iot_az_dt_twin_query
+  - ext_azure-iot_az_dt_twin_show
+  - ext_azure-iot_az_dt_twin_update
+- uid: ext_azure-iot_az_dt_twin_create
+  name: az dt twin create
+  summary: Create a digital twin on an instance.
+  description: --properties can be inline JSON or file path.
+  langs:
+  - azurecli
+  examples:
+  - summary: Create a digital twin from an existing (prior-created) model.
+    syntax:
+      content: az dt twin create -n {instance_name} --dtmi urn:azureiot:DeviceManagement:DeviceInformation:1 --twin-id {twin_id}
+  - summary: Create a digital twin from an existing (prior-created) model. Instantiate with property values.
+    syntax:
+      content: "az dt twin create -n {instance_name} --dtmi urn:azureiot:DeviceManagement:DeviceInformation:1 --twin-id {twin_id} --properties '{\"manufacturer\": \"Microsoft\"}'"
+  - summary: Create a digital twin with component from existing (prior-created) models. Instantiate with property values.
+    syntax:
+      content: >-
+        az dt twin create -n {instance_name} --dtmi dtmi:example:Room;1 --twin-id {twin_id} --properties '{
+            "Temperature": 10.2,
+            "Thermostat": {
+                "$metadata": {},
+                "setPointTemp": 23.12
+            }
+        }'
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --dtmi --model-id -m
+    summary: 'Digital Twins model Id. Example: dtmi:example:Room;2.'
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --properties -p
+    summary: Initial property values for instantiating a digital twin or related components. Provide file path or inline JSON.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_delete
+  name: az dt twin delete
+  summary: Remove a digital twin. All relationships referencing this twin must already be deleted.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Remove a digital twin by Id.
+    syntax:
+      content: az dt twin delete -n {instance_name} --twin-id {twin_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_query
+  name: az dt twin query
+  summary: Query the digital twins of an instance. Allows traversing relationships and filtering by property values.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Query all digital twins in target instance and project all attributes. Also show cost in query units.
+    syntax:
+      content: az dt twin query -n {instance_name} -q "select * from digitaltwins" --show-cost
+  - summary: Query by model and project all attributes.
+    syntax:
+      content: az dt twin query -n {instance_name} -q "select * from digitaltwins T where IS_OF_MODEL(T, 'dtmi:example:Room;2')"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --query-command -q
+    summary: User query to be executed.
+    description: ''
+  - name: --cost --show-cost
+    parameterValueGroup: false, true
+    summary: Calculates and shows the query charge.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_show
+  name: az dt twin show
+  summary: Show the details of a digital twin.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show the details of a digital twin.
+    syntax:
+      content: az dt twin show -n {instance_name} --twin-id {twin_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_update
+  name: az dt twin update
+  summary: Update an instance digital twin via JSON patch specification.
+  description: Updates to property values and $model elements may happen in the same request. Operations are limited to add, replace and remove.
+  langs:
+  - azurecli
+  examples:
+  - summary: Update a digital twin via JSON patch specification.
+    syntax:
+      content: "az dt twin update -n {instance_name} --twin-id {twin_id} --json-patch '{\"op\":\"replace\", \"path\":\"/Temperature\", \"value\": 20.5}'"
+  - summary: Update a digital twin via JSON patch specification.
+    syntax:
+      content: >-
+        az dt twin update -n {instance_name} --twin-id {twin_id} --json-patch '[
+          {"op":"replace", "path":"/Temperature", "value": 20.5},
+          {"op":"add", "path":"/Areas", "value": ["ControlSystem"]}
+        ]'
+  - summary: Update a digital twin via JSON patch specification defined in a file.
+    syntax:
+      content: az dt twin update -n {instance_name} --twin-id {twin_id} --json-patch ./my/patch/document.json
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --json-patch --patch
+    summary: An update specification described by JSON-patch. Updates to property values and $model elements may happen in the same request. Operations are limited to add, replace and remove. Provide file path or inline JSON.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_twin_component
+  name: az dt twin component
+  summary: Show and update the digital twin components of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_component_show
+  name: az dt twin component show
+  summary: Show details of a digital twin component.
+- uid: ext_azure-iot_az_dt_twin_component_update
+  name: az dt twin component update
+  summary: Update a digital twin component via JSON patch specification.
+- uid: ext_azure-iot_az_dt_twin_create
+  name: az dt twin create
+  summary: Create a digital twin on an instance.
+- uid: ext_azure-iot_az_dt_twin_delete
+  name: az dt twin delete
+  summary: Remove a digital twin. All relationships referencing this twin must already be deleted.
+- uid: ext_azure-iot_az_dt_twin_query
+  name: az dt twin query
+  summary: Query the digital twins of an instance. Allows traversing relationships and filtering by property values.
+- uid: ext_azure-iot_az_dt_twin_relationship
+  name: az dt twin relationship
+  summary: Manage and configure the digital twin relationships of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_relationship_create
+  name: az dt twin relationship create
+  summary: Create a relationship between source and target digital twins.
+- uid: ext_azure-iot_az_dt_twin_relationship_delete
+  name: az dt twin relationship delete
+  summary: Delete a digital twin relationship on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_relationship_list
+  name: az dt twin relationship list
+  summary: List the relationships of a digital twin.
+- uid: ext_azure-iot_az_dt_twin_relationship_show
+  name: az dt twin relationship show
+  summary: Show details of a digital twin relationship.
+- uid: ext_azure-iot_az_dt_twin_relationship_update
+  name: az dt twin relationship update
+  summary: Updates the properties of a relationship between two digital twins via JSON patch specification.
+- uid: ext_azure-iot_az_dt_twin_show
+  name: az dt twin show
+  summary: Show the details of a digital twin.
+- uid: ext_azure-iot_az_dt_twin_telemetry
+  name: az dt twin telemetry
+  summary: Test and validate the event routes and endpoints of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_telemetry_send
+  name: az dt twin telemetry send
+  summary: Sends telemetry on behalf of a digital twin. If component path is provided the emitted telemetry is on behalf of the component.
+- uid: ext_azure-iot_az_dt_twin_update
+  name: az dt twin update
+  summary: Update an instance digital twin via JSON patch specification.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Manage and configure the digital twins of a Digital Twins instance.

--- a/2018-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/twin/component.yml
+++ b/2018-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/twin/component.yml
@@ -1,0 +1,100 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_twin_component
+  name: az dt twin component
+  summary: Show and update the digital twin components of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_twin_component_show
+  - ext_azure-iot_az_dt_twin_component_update
+- uid: ext_azure-iot_az_dt_twin_component_show
+  name: az dt twin component show
+  summary: Show details of a digital twin component.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show details of a digital twin component
+    syntax:
+      content: az dt twin component show -n {instance_name} --twin-id {twin_id} --component Thermostat
+  parameters:
+  - isRequired: true
+    name: --component
+    summary: The path to the DTDL component.
+    description: ''
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_component_update
+  name: az dt twin component update
+  summary: Update a digital twin component via JSON patch specification.
+  description: Updates to property values and $model elements may happen in the same request. Operations are limited to add, replace and remove.
+  langs:
+  - azurecli
+  examples:
+  - summary: Update a digital twin component via JSON patch specification.
+    syntax:
+      content: "az dt twin component update -n {instance_name} --twin-id {twin_id} --component {component_path} --json-patch '{\"op\":\"replace\", \"path\":\"/Temperature\", \"value\": 20.5}'"
+  - summary: Update a digital twin component via JSON patch specification.
+    syntax:
+      content: >-
+        az dt twin component update -n {instance_name} --twin-id {twin_id} --component {component_path} --json-patch '[
+          {"op":"replace", "path":"/Temperature", "value": 20.5},
+          {"op":"add", "path":"/Areas", "value": ["ControlSystem"]}
+        ]'
+  - summary: Update a digital twin component via JSON patch specification defined in a file.
+    syntax:
+      content: az dt twin component update -n {instance_name} --twin-id {twin_id} --component {component_path} --json-patch ./my/patch/document.json
+  parameters:
+  - isRequired: true
+    name: --component
+    summary: The path to the DTDL component.
+    description: ''
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --json-patch --patch
+    summary: An update specification described by JSON-patch. Updates to property values and $model elements may happen in the same request. Operations are limited to add, replace and remove. Provide file path or inline JSON.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_twin_component_show
+  name: az dt twin component show
+  summary: Show details of a digital twin component.
+- uid: ext_azure-iot_az_dt_twin_component_update
+  name: az dt twin component update
+  summary: Update a digital twin component via JSON patch specification.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Show and update the digital twin components of a Digital Twins instance.

--- a/2018-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/twin/relationship.yml
+++ b/2018-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/twin/relationship.yml
@@ -1,0 +1,216 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_twin_relationship
+  name: az dt twin relationship
+  summary: Manage and configure the digital twin relationships of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_twin_relationship_create
+  - ext_azure-iot_az_dt_twin_relationship_delete
+  - ext_azure-iot_az_dt_twin_relationship_list
+  - ext_azure-iot_az_dt_twin_relationship_show
+  - ext_azure-iot_az_dt_twin_relationship_update
+- uid: ext_azure-iot_az_dt_twin_relationship_create
+  name: az dt twin relationship create
+  summary: Create a relationship between source and target digital twins.
+  description: --properties can be inline JSON or file path.
+  langs:
+  - azurecli
+  examples:
+  - summary: Create a relationship between two digital twins.
+    syntax:
+      content: az dt twin relationship create -n {instance_name} --relationship-id {relationship_id} --relationship contains --source {source_twin_id} --target {target_twin_id}
+  - summary: Create a relationship with initialized properties between two digital twins.
+    syntax:
+      content: "az dt twin relationship create -n {instance_name} --relationship-id {relationship_id} --relationship contains --source {source_twin_id} --target {target_twin_id} --properties '{\"ownershipUser\": \"me\", \"ownershipDepartment\": \"Computer Science\"}'"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --kind --relationship
+    summary: "Relationship name or kind. For example: 'contains'."
+    description: ''
+  - isRequired: true
+    name: --relationship-id -r
+    summary: Relationship Id.
+    description: ''
+  - isRequired: true
+    name: --source --source-twin-id -s
+    summary: The source twin Id for a relationship.
+    description: ''
+  - isRequired: true
+    name: --target --target-twin-id -t
+    summary: The target twin Id for a relationship.
+    description: ''
+  - name: --properties -p
+    summary: Initial property values for instantiating a digital twin relationship. Provide file path or inline JSON.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_relationship_delete
+  name: az dt twin relationship delete
+  summary: Delete a digital twin relationship on a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Delete a digital twin relationship.
+    syntax:
+      content: az dt twin relationship delete -n {instance_name} --twin-id {twin_id} --relationship-id {relationship_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --relationship-id -r
+    summary: Relationship Id.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_relationship_list
+  name: az dt twin relationship list
+  summary: List the relationships of a digital twin.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List outgoing relationships of a digital twin.
+    syntax:
+      content: az dt twin relationship list -n {instance_name} --twin-id {twin_id}
+  - summary: List outgoing relationships of a digital twin and filter on relationship 'contains'
+    syntax:
+      content: az dt twin relationship list -n {instance_name} --twin-id {twin_id} --relationship contains
+  - summary: List incoming relationships of a digital twin.
+    syntax:
+      content: az dt twin relationship list -n {instance_name} --twin-id {twin_id} --incoming
+  - summary: List incoming relationships of a digital twin and filter on relationship 'contains'.
+    syntax:
+      content: az dt twin relationship list -n {instance_name} --twin-id {twin_id} --relationship contains --incoming
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --incoming
+    parameterValueGroup: false, true
+    summary: Retrieves all incoming relationships for a digital twin.
+    description: ''
+  - name: --kind --relationship
+    summary: Filter result by the kind of relationship.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_relationship_show
+  name: az dt twin relationship show
+  summary: Show details of a digital twin relationship.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show details of a digital twin relationship.
+    syntax:
+      content: az dt twin relationship show -n {instance_name} --twin-id {twin_id} --relationship-id {relationship_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --relationship-id -r
+    summary: Relationship Id.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_relationship_update
+  name: az dt twin relationship update
+  summary: Updates the properties of a relationship between two digital twins via JSON patch specification.
+  description: Operations are limited to add, replace and remove.
+  langs:
+  - azurecli
+  examples:
+  - summary: Update a digital twin relationship via JSON patch specification.
+    syntax:
+      content: "az dt twin relationship update -n {instance_name} --twin-id {twin_id} --relationship-id {relationship_id} --relationship contains --json-patch '{\"op\":\"replace\", \"path\":\"/Temperature\", \"value\": 20.5}'"
+  - summary: Update a digital twin relationship via JSON patch specification.
+    syntax:
+      content: >-
+        az dt twin relationship update -n {instance_name} --twin-id {twin_id} --relationship-id {relationship_id} --relationship contains --json-patch '[
+          {"op":"replace", "path":"/Temperature", "value": 20.5},
+          {"op":"add", "path":"/Areas", "value": ["ControlSystem"]}
+        ]'
+  - summary: Update a digital twin relationship via JSON patch specification defined in a file.
+    syntax:
+      content: az dt twin relationship update -n {instance_name} --twin-id {twin_id} --relationship-id {relationship_id} --relationship contains --json-patch ./my/patch/document.json
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --json-patch --patch
+    summary: An update specification described by JSON-patch. Updates to property values and $model elements may happen in the same request. Operations are limited to add, replace and remove. Provide file path or inline JSON.
+    description: ''
+  - isRequired: true
+    name: --relationship-id -r
+    summary: Relationship Id.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_twin_relationship_create
+  name: az dt twin relationship create
+  summary: Create a relationship between source and target digital twins.
+- uid: ext_azure-iot_az_dt_twin_relationship_delete
+  name: az dt twin relationship delete
+  summary: Delete a digital twin relationship on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_relationship_list
+  name: az dt twin relationship list
+  summary: List the relationships of a digital twin.
+- uid: ext_azure-iot_az_dt_twin_relationship_show
+  name: az dt twin relationship show
+  summary: Show details of a digital twin relationship.
+- uid: ext_azure-iot_az_dt_twin_relationship_update
+  name: az dt twin relationship update
+  summary: Updates the properties of a relationship between two digital twins via JSON patch specification.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Manage and configure the digital twin relationships of a Digital Twins instance.

--- a/2018-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/twin/telemetry.yml
+++ b/2018-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/twin/telemetry.yml
@@ -1,0 +1,61 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_twin_telemetry
+  name: az dt twin telemetry
+  summary: Test and validate the event routes and endpoints of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_twin_telemetry_send
+- uid: ext_azure-iot_az_dt_twin_telemetry_send
+  name: az dt twin telemetry send
+  summary: Sends telemetry on behalf of a digital twin. If component path is provided the emitted telemetry is on behalf of the component.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Send twin telemetry
+    syntax:
+      content: az dt twin telemetry send -n {instance_name} --twin-id {twin_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --component
+    summary: The path to the DTDL component. If set, telemetry will be emitted on behalf of the component.
+    description: ''
+  - name: --dt-id
+    summary: A unique message identifier (in the scope of the digital twin id) that is commonly used for de-duplicating messages. If no value is provided a GUID is automatically generated.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --telemetry
+    summary: 'Inline telemetry JSON or file path to telemetry JSON. Default payload is an empty object: {}.'
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_twin_telemetry_send
+  name: az dt twin telemetry send
+  summary: Sends telemetry on behalf of a digital twin. If component path is provided the emitted telemetry is on behalf of the component.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Test and validate the event routes and endpoints of a Digital Twins instance.

--- a/2018-03-01-hybrid/docs-ref-autogen/ext/azure-iot/index.yml
+++ b/2018-03-01-hybrid/docs-ref-autogen/ext/azure-iot/index.yml
@@ -8,6 +8,9 @@ items:
   - azurecli
   children: []
 commands:
+- uid: ext_azure-iot_az_dt
+  name: az dt
+  summary: Manage Azure Digital Twins (ADT) solutions & infrastructure.
 - uid: ext_azure-iot_az_iot
   name: az iot
   summary: Manage Internet of Things (IoT) assets. Augmented with the IoT extension.

--- a/2019-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt.yml
+++ b/2019-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt.yml
@@ -1,0 +1,253 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt
+  name: az dt
+  summary: Manage Azure Digital Twins (ADT) solutions & infrastructure.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_create
+  - ext_azure-iot_az_dt_delete
+  - ext_azure-iot_az_dt_list
+  - ext_azure-iot_az_dt_show
+- uid: ext_azure-iot_az_dt_create
+  name: az dt create
+  summary: Create a new Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Create instance in target resource group with default location.
+    syntax:
+      content: az dt create -n {instance_name} -g {resouce_group} -l eastus2euap
+  - summary: Create instance in target resource group with specified location and tags.
+    syntax:
+      content: az dt create -n {instance_name} -g {resouce_group} -l westcentralus --tags "a=b;c=d"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --location -l
+    summary: Digital Twins instance location. You can configure the default location using `az configure --defaults location=&lt;name&gt;`.
+    description: ''
+  - isRequired: true
+    name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --tags
+    summary: 'Digital Twins instance tags. Property bag in key-value pairs with the following format: a=b;c=d.'
+    description: ''
+- uid: ext_azure-iot_az_dt_delete
+  name: az dt delete
+  summary: Delete an existing Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Delete an arbitrary instance.
+    syntax:
+      content: az dt delete -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_list
+  name: az dt list
+  summary: List the collection of Digital Twins instances by subscription or resource group.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List all instances in the current subscription.
+    syntax:
+      content: az dt list
+  - summary: List all instances in target resource group and output in table format.
+    syntax:
+      content: az dt list -g {resource_group} --output table
+  - summary: List all instances in subscription that meet a condition.
+    syntax:
+      content: az dt list --query "[?contains(name, 'Production')]"
+  - summary: Count instances that meet condition.
+    syntax:
+      content: az dt list --query "length([?contains(name, 'Production')])"
+  parameters:
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_show
+  name: az dt show
+  summary: Show an existing Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show an instance.
+    syntax:
+      content: az dt show -n {instance_name}
+  - summary: Show an instance and project certain properties.
+    syntax:
+      content: az dt show -n {instance_name} --query "{Endpoint:hostName, Location:location}"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_create
+  name: az dt create
+  summary: Create a new Digital Twins instance.
+- uid: ext_azure-iot_az_dt_delete
+  name: az dt delete
+  summary: Delete an existing Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint
+  name: az dt endpoint
+  summary: Manage and configure Digital Twins instance endpoints.
+- uid: ext_azure-iot_az_dt_endpoint_create
+  name: az dt endpoint create
+  summary: Add egress endpoints to a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_create_eventgrid
+  name: az dt endpoint create eventgrid
+  summary: Adds an EventGrid Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_eventhub
+  name: az dt endpoint create eventhub
+  summary: Adds an EventHub endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_servicebus
+  name: az dt endpoint create servicebus
+  summary: Adds a ServiceBus Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_delete
+  name: az dt endpoint delete
+  summary: Remove an endpoint from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_list
+  name: az dt endpoint list
+  summary: List all egress endpoints configured on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_show
+  name: az dt endpoint show
+  summary: Show details of an endpoint configured on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_list
+  name: az dt list
+  summary: List the collection of Digital Twins instances by subscription or resource group.
+- uid: ext_azure-iot_az_dt_model
+  name: az dt model
+  summary: Manage DTDL models and definitions on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_model_create
+  name: az dt model create
+  summary: Uploads one or more models. When any error occurs, no models are uploaded.
+- uid: ext_azure-iot_az_dt_model_delete
+  name: az dt model delete
+  summary: Delete a model. A model can only be deleted if no other models reference it.
+- uid: ext_azure-iot_az_dt_model_list
+  name: az dt model list
+  summary: List model metadata, definitions and dependencies.
+- uid: ext_azure-iot_az_dt_model_show
+  name: az dt model show
+  summary: Retrieve a target model or model definition.
+- uid: ext_azure-iot_az_dt_model_update
+  name: az dt model update
+  summary: Updates the metadata for a model. Currently a model can only be decommisioned.
+- uid: ext_azure-iot_az_dt_role_assignment
+  name: az dt role-assignment
+  summary: Manage RBAC role assignments for a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_role_assignment_create
+  name: az dt role-assignment create
+  summary: Assign a user, group or service principal to a role against a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_role_assignment_delete
+  name: az dt role-assignment delete
+  summary: Remove a user, group or service principal role assignment from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_role_assignment_list
+  name: az dt role-assignment list
+  summary: List the existing role assignments of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route
+  name: az dt route
+  summary: Manage and configure event routes.
+- uid: ext_azure-iot_az_dt_route_create
+  name: az dt route create
+  summary: Add an event route to a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_delete
+  name: az dt route delete
+  summary: Remove an event route from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_list
+  name: az dt route list
+  summary: List the configured event routes of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_show
+  name: az dt route show
+  summary: Show details of an event route configured on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_show
+  name: az dt show
+  summary: Show an existing Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin
+  name: az dt twin
+  summary: Manage and configure the digital twins of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_component
+  name: az dt twin component
+  summary: Show and update the digital twin components of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_component_show
+  name: az dt twin component show
+  summary: Show details of a digital twin component.
+- uid: ext_azure-iot_az_dt_twin_component_update
+  name: az dt twin component update
+  summary: Update a digital twin component via JSON patch specification.
+- uid: ext_azure-iot_az_dt_twin_create
+  name: az dt twin create
+  summary: Create a digital twin on an instance.
+- uid: ext_azure-iot_az_dt_twin_delete
+  name: az dt twin delete
+  summary: Remove a digital twin. All relationships referencing this twin must already be deleted.
+- uid: ext_azure-iot_az_dt_twin_query
+  name: az dt twin query
+  summary: Query the digital twins of an instance. Allows traversing relationships and filtering by property values.
+- uid: ext_azure-iot_az_dt_twin_relationship
+  name: az dt twin relationship
+  summary: Manage and configure the digital twin relationships of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_relationship_create
+  name: az dt twin relationship create
+  summary: Create a relationship between source and target digital twins.
+- uid: ext_azure-iot_az_dt_twin_relationship_delete
+  name: az dt twin relationship delete
+  summary: Delete a digital twin relationship on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_relationship_list
+  name: az dt twin relationship list
+  summary: List the relationships of a digital twin.
+- uid: ext_azure-iot_az_dt_twin_relationship_show
+  name: az dt twin relationship show
+  summary: Show details of a digital twin relationship.
+- uid: ext_azure-iot_az_dt_twin_relationship_update
+  name: az dt twin relationship update
+  summary: Updates the properties of a relationship between two digital twins via JSON patch specification.
+- uid: ext_azure-iot_az_dt_twin_show
+  name: az dt twin show
+  summary: Show the details of a digital twin.
+- uid: ext_azure-iot_az_dt_twin_telemetry
+  name: az dt twin telemetry
+  summary: Test and validate the event routes and endpoints of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_telemetry_send
+  name: az dt twin telemetry send
+  summary: Sends telemetry on behalf of a digital twin. If component path is provided the emitted telemetry is on behalf of the component.
+- uid: ext_azure-iot_az_dt_twin_update
+  name: az dt twin update
+  summary: Update an instance digital twin via JSON patch specification.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Manage Azure Digital Twins (ADT) solutions & infrastructure.

--- a/2019-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/endpoint.yml
+++ b/2019-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/endpoint.yml
@@ -1,0 +1,112 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_endpoint
+  name: az dt endpoint
+  summary: Manage and configure Digital Twins instance endpoints.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_endpoint_delete
+  - ext_azure-iot_az_dt_endpoint_list
+  - ext_azure-iot_az_dt_endpoint_show
+- uid: ext_azure-iot_az_dt_endpoint_delete
+  name: az dt endpoint delete
+  summary: Remove an endpoint from a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Remove an endpoint from an instance.
+    syntax:
+      content: az dt endpoint delete -n {instance_name} --endpoint-name {endpoint_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_endpoint_list
+  name: az dt endpoint list
+  summary: List all egress endpoints configured on a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List all egress endpoints configured on an instance.
+    syntax:
+      content: az dt endpoint list -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_endpoint_show
+  name: az dt endpoint show
+  summary: Show details of an endpoint configured on a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show a desired endpoint by name on an instance.
+    syntax:
+      content: az dt endpoint show -n {instance_name} --endpoint-name {endpoint_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_endpoint_create
+  name: az dt endpoint create
+  summary: Add egress endpoints to a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_create_eventgrid
+  name: az dt endpoint create eventgrid
+  summary: Adds an EventGrid Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_eventhub
+  name: az dt endpoint create eventhub
+  summary: Adds an EventHub endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_servicebus
+  name: az dt endpoint create servicebus
+  summary: Adds a ServiceBus Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_delete
+  name: az dt endpoint delete
+  summary: Remove an endpoint from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_list
+  name: az dt endpoint list
+  summary: List all egress endpoints configured on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_show
+  name: az dt endpoint show
+  summary: Show details of an endpoint configured on a Digital Twins instance.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Manage and configure Digital Twins instance endpoints.

--- a/2019-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/endpoint/create.yml
+++ b/2019-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/endpoint/create.yml
@@ -1,0 +1,153 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_endpoint_create
+  name: az dt endpoint create
+  summary: Add egress endpoints to a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_endpoint_create_eventgrid
+  - ext_azure-iot_az_dt_endpoint_create_eventhub
+  - ext_azure-iot_az_dt_endpoint_create_servicebus
+- uid: ext_azure-iot_az_dt_endpoint_create_eventgrid
+  name: az dt endpoint create eventgrid
+  summary: Adds an EventGrid Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Adds an EventGrid Topic endpoint to a target instance.
+    syntax:
+      content: az dt endpoint create eventgrid --endpoint-name {endpoint_name} --eventgrid-resource-group {eventgrid_resource_group} --eventgrid-topic {eventgrid_topic_name} -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --tags
+    summary: 'Digital Twins endpoint tags. Property bag in key-value pairs with the following format: a=b;c=d.'
+    description: ''
+  - isRequired: true
+    name: --egg --eventgrid-resource-group
+    summary: Name of EventGrid Topic resource group.
+    description: ''
+  - isRequired: true
+    name: --egt --eventgrid-topic
+    summary: Name of EventGrid Topic to integrate with.
+    description: ''
+- uid: ext_azure-iot_az_dt_endpoint_create_eventhub
+  name: az dt endpoint create eventhub
+  summary: Adds an EventHub endpoint to a Digital Twins instance. Requires pre-created resource.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Adds an EventHub endpoint to a target instance.
+    syntax:
+      content: az dt endpoint create eventhub --endpoint-name {endpoint_name} --eventhub-resource-group {eventhub_resource_group} --eventhub-namespace {eventhub_namespace} --eventhub {eventhub_name} --eventhub-policy {eventhub_policy} -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --tags
+    summary: 'Digital Twins endpoint tags. Property bag in key-value pairs with the following format: a=b;c=d.'
+    description: ''
+  - isRequired: true
+    name: --eh --eventhub
+    summary: Name of EventHub to integrate with.
+    description: ''
+  - isRequired: true
+    name: --ehg --eventhub-resource-group
+    summary: Name of EventHub resource group.
+    description: ''
+  - isRequired: true
+    name: --ehn --eventhub-namespace
+    summary: EventHub Namespace identifier.
+    description: ''
+  - isRequired: true
+    name: --ehp --eventhub-policy
+    summary: EventHub policy to use for endpoint configuration.
+    description: ''
+- uid: ext_azure-iot_az_dt_endpoint_create_servicebus
+  name: az dt endpoint create servicebus
+  summary: Adds a ServiceBus Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Adds a ServiceBus Topic endpoint to a target instance.
+    syntax:
+      content: az dt endpoint create servicebus --endpoint-name {endpoint_name} --servicebus-resource-group {servicebus_resource_group} --servicebus-namespace {servicebus_namespace} --servicebus-topic {servicebus_topic_name} --servicebus-policy {servicebus_policy} -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --tags
+    summary: 'Digital Twins endpoint tags. Property bag in key-value pairs with the following format: a=b;c=d.'
+    description: ''
+  - isRequired: true
+    name: --sbg --servicebus-resource-group
+    summary: Name of ServiceBus resource group.
+    description: ''
+  - isRequired: true
+    name: --sbn --servicebus-namespace
+    summary: ServiceBus Namespace identifier.
+    description: ''
+  - isRequired: true
+    name: --sbp --servicebus-policy
+    summary: ServiceBus Topic policy to use for endpoint configuration.
+    description: ''
+  - isRequired: true
+    name: --sbt --servicebus-topic
+    summary: Name of ServiceBus Topic to integrate with.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_endpoint_create_eventgrid
+  name: az dt endpoint create eventgrid
+  summary: Adds an EventGrid Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_eventhub
+  name: az dt endpoint create eventhub
+  summary: Adds an EventHub endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_servicebus
+  name: az dt endpoint create servicebus
+  summary: Adds a ServiceBus Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Add egress endpoints to a Digital Twins instance.

--- a/2019-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/model.yml
+++ b/2019-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/model.yml
@@ -1,0 +1,181 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_model
+  name: az dt model
+  summary: Manage DTDL models and definitions on a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_model_create
+  - ext_azure-iot_az_dt_model_delete
+  - ext_azure-iot_az_dt_model_list
+  - ext_azure-iot_az_dt_model_show
+  - ext_azure-iot_az_dt_model_update
+- uid: ext_azure-iot_az_dt_model_create
+  name: az dt model create
+  summary: Uploads one or more models. When any error occurs, no models are uploaded.
+  description: --models can be inline json or file path.
+  langs:
+  - azurecli
+  examples:
+  - summary: Bulk upload all .json or .dtdl model files from a target directory. Model processing is recursive.
+    syntax:
+      content: az dt model create -n {instance_name} --from-directory {directory_path}
+  - summary: Upload model json inline or from file path.
+    syntax:
+      content: az dt model create -n {instance_name} --models {file_path_or_inline_json}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --fd --from-directory
+    summary: The directory JSON model files will be parsed from.
+    description: ''
+  - name: --models
+    summary: Inline model JSON or file path to model JSON.
+    description: ''
+- uid: ext_azure-iot_az_dt_model_delete
+  name: az dt model delete
+  summary: Delete a model. A model can only be deleted if no other models reference it.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Delete a target model.
+    syntax:
+      content: az dt model delete -n {instance_name} --dtmi "dtmi:example:Floor;1"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --dtmi --model-id -m
+    summary: 'Digital Twins model Id. Example: dtmi:example:Room;2.'
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_model_list
+  name: az dt model list
+  summary: List model metadata, definitions and dependencies.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List model metadata
+    syntax:
+      content: az dt model list -n {instance_name}
+  - summary: List model definitions
+    syntax:
+      content: az dt model list -n {instance_name} --definition
+  - summary: List dependencies of particular pre-existing model(s). Space seperate dtmi values.
+    syntax:
+      content: az dt model list -n {instance_name} --dependencies-for {model_id0} {model_id1}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --def --definition
+    parameterValueGroup: false, true
+    summary: The operation will retrieve the model definition.
+    description: ''
+  - name: --dependencies-for
+    summary: The set of models which will have their dependencies retrieved. If omitted, all models are retrieved. Format is a whitespace separated list.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_model_show
+  name: az dt model show
+  summary: Retrieve a target model or model definition.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show model meta data
+    syntax:
+      content: az dt model show -n {instance_name} --dtmi "dtmi:example:Floor;1"
+  - summary: Show model meta data and definition
+    syntax:
+      content: az dt model show -n {instance_name} --dtmi "dtmi:example:Floor;1" --definition
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --dtmi --model-id -m
+    summary: 'Digital Twins model Id. Example: dtmi:example:Room;2.'
+    description: ''
+  - name: --def --definition
+    parameterValueGroup: false, true
+    summary: The operation will retrieve the model definition.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_model_update
+  name: az dt model update
+  summary: Updates the metadata for a model. Currently a model can only be decommisioned.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Decommision a target model
+    syntax:
+      content: az dt model update -n {instance_name} --dtmi "dtmi:example:Floor;1" --decommission
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --dtmi --model-id -m
+    summary: 'Digital Twins model Id. Example: dtmi:example:Room;2.'
+    description: ''
+  - name: --decommission
+    parameterValueGroup: false, true
+    summary: Indicates intent to decommission a target model.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_model_create
+  name: az dt model create
+  summary: Uploads one or more models. When any error occurs, no models are uploaded.
+- uid: ext_azure-iot_az_dt_model_delete
+  name: az dt model delete
+  summary: Delete a model. A model can only be deleted if no other models reference it.
+- uid: ext_azure-iot_az_dt_model_list
+  name: az dt model list
+  summary: List model metadata, definitions and dependencies.
+- uid: ext_azure-iot_az_dt_model_show
+  name: az dt model show
+  summary: Retrieve a target model or model definition.
+- uid: ext_azure-iot_az_dt_model_update
+  name: az dt model update
+  summary: Updates the metadata for a model. Currently a model can only be decommisioned.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Manage DTDL models and definitions on a Digital Twins instance.

--- a/2019-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/role-assignment.yml
+++ b/2019-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/role-assignment.yml
@@ -1,0 +1,141 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_role_assignment
+  name: az dt role-assignment
+  summary: Manage RBAC role assignments for a Digital Twins instance.
+  description: >-
+    Note that in order to perform role assignments, the logged in principal needs permissions
+
+    such as Owner or User Access Administrator at the assigned scope.
+
+
+    This command group is provided for convenience. For more complex role assignment scenarios
+
+    use the 'az role assignment' command group.
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_role_assignment_create
+  - ext_azure-iot_az_dt_role_assignment_delete
+  - ext_azure-iot_az_dt_role_assignment_list
+- uid: ext_azure-iot_az_dt_role_assignment_create
+  name: az dt role-assignment create
+  summary: Assign a user, group or service principal to a role against a Digital Twins instance.
+  description: Note that in order to perform role assignments, the logged in principal needs permissions such as Owner or User Access Administrator at the assigned scope.
+  langs:
+  - azurecli
+  examples:
+  - summary: Assign a user (by email) the built-in Digital Twins Owner role against a target instance.
+    syntax:
+      content: az dt role-assignment create -n {instance_name} --assignee "owneruser@microsoft.com" --role "Azure Digital Twins Owner (Preview)"
+  - summary: Assign a user (by object Id) the built-in Digital Twins Reader role against a target instance.
+    syntax:
+      content: az dt role-assignment create -n {instance_name} --assignee "97a89267-0966-4054-a156-b7d86ef8e216" --role "Azure Digital Twins Reader (Preview)"
+  - summary: Assign a service principal a custom role against a target instance.
+    syntax:
+      content: az dt role-assignment create -n {instance_name} --assignee {service_principal_name_or_id} --role {role_name_or_id}
+  parameters:
+  - isRequired: true
+    name: --assignee
+    summary: 'Represent a user, group, or service principal. supported format: object id, user sign-in name, or service principal name.'
+    description: ''
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --role
+    summary: Role name or Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_role_assignment_delete
+  name: az dt role-assignment delete
+  summary: Remove a user, group or service principal role assignment from a Digital Twins instance.
+  description: Note that in order to perform role assignments, the logged in principal needs permissions such as Owner or User Access Administrator at the assigned scope.
+  langs:
+  - azurecli
+  examples:
+  - summary: Remove a user from a specific role assignment of a Digital Twins instance.
+    syntax:
+      content: az dt role-assignment delete -n {instance_name} --assignee "removeuser@microsoft.com" --role "Azure Digital Twins Reader (Preview)"
+  - summary: Remove a user from all assigned roles of a Digital Twins instance.
+    syntax:
+      content: az dt role-assignment delete -n {instance_name} --assignee "removeuser@microsoft.com"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --assignee
+    summary: 'Represent a user, group, or service principal. supported format: object id, user sign-in name, or service principal name.'
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --role
+    summary: Role name or Id.
+    description: ''
+- uid: ext_azure-iot_az_dt_role_assignment_list
+  name: az dt role-assignment list
+  summary: List the existing role assignments of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List the role assignments on a target instance.
+    syntax:
+      content: az dt role-assignment list -n {instance_name}
+  - summary: List the role assignments on a target instance and filter by role.
+    syntax:
+      content: az dt role-assignment list -n {instance_name} --role {role_name_or_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --include-inherited
+    parameterValueGroup: false, true
+    summary: Include assignments applied on parent scopes.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --role
+    summary: Role name or Id.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_role_assignment_create
+  name: az dt role-assignment create
+  summary: Assign a user, group or service principal to a role against a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_role_assignment_delete
+  name: az dt role-assignment delete
+  summary: Remove a user, group or service principal role assignment from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_role_assignment_list
+  name: az dt role-assignment list
+  summary: List the existing role assignments of a Digital Twins instance.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: >-
+  Note that in order to perform role assignments, the logged in principal needs permissions
+
+  such as Owner or User Access Administrator at the assigned scope.
+
+
+  This command group is provided for convenience. For more complex role assignment scenarios
+
+  use the 'az role assignment' command group.

--- a/2019-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/route.yml
+++ b/2019-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/route.yml
@@ -1,0 +1,137 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_route
+  name: az dt route
+  summary: Manage and configure event routes.
+  description: Note that an endpoint must first be configred before adding an event route.
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_route_create
+  - ext_azure-iot_az_dt_route_delete
+  - ext_azure-iot_az_dt_route_list
+  - ext_azure-iot_az_dt_route_show
+- uid: ext_azure-iot_az_dt_route_create
+  name: az dt route create
+  summary: Add an event route to a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Adds an event route for an existing endpoint on target instance with default filter of "true".
+    syntax:
+      content: az dt route create -n {instance_name} --endpoint-name {endpoint_name} --route-name {route_name}
+  - summary: Adds an event route for an existing endpoint on target instance with custom filter.
+    syntax:
+      content: az dt route create -n {instance_name} --endpoint-name {endpoint_name} --route-name {route_name} --filter "type = 'Microsoft.DigitalTwins.Twin.Create'"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - isRequired: true
+    name: --rn --route-name
+    summary: Event route name.
+    description: ''
+  - name: --filter
+    defaultValue: "true"
+    summary: Event route filter.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_route_delete
+  name: az dt route delete
+  summary: Remove an event route from a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Remove an event route from a target instance.
+    syntax:
+      content: az dt route delete -n {instance_name} --route-name {route_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --rn --route-name
+    summary: Event route name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_route_list
+  name: az dt route list
+  summary: List the configured event routes of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List configured event routes of a target instance.
+    syntax:
+      content: az dt route list -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_route_show
+  name: az dt route show
+  summary: Show details of an event route configured on a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show an event route on a target instance.
+    syntax:
+      content: az dt route show -n {instance_name} --route-name {route_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --rn --route-name
+    summary: Event route name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_route_create
+  name: az dt route create
+  summary: Add an event route to a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_delete
+  name: az dt route delete
+  summary: Remove an event route from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_list
+  name: az dt route list
+  summary: List the configured event routes of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_show
+  name: az dt route show
+  summary: Show details of an event route configured on a Digital Twins instance.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Note that an endpoint must first be configred before adding an event route.

--- a/2019-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/twin.yml
+++ b/2019-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/twin.yml
@@ -1,0 +1,230 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_twin
+  name: az dt twin
+  summary: Manage and configure the digital twins of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_twin_create
+  - ext_azure-iot_az_dt_twin_delete
+  - ext_azure-iot_az_dt_twin_query
+  - ext_azure-iot_az_dt_twin_show
+  - ext_azure-iot_az_dt_twin_update
+- uid: ext_azure-iot_az_dt_twin_create
+  name: az dt twin create
+  summary: Create a digital twin on an instance.
+  description: --properties can be inline JSON or file path.
+  langs:
+  - azurecli
+  examples:
+  - summary: Create a digital twin from an existing (prior-created) model.
+    syntax:
+      content: az dt twin create -n {instance_name} --dtmi urn:azureiot:DeviceManagement:DeviceInformation:1 --twin-id {twin_id}
+  - summary: Create a digital twin from an existing (prior-created) model. Instantiate with property values.
+    syntax:
+      content: "az dt twin create -n {instance_name} --dtmi urn:azureiot:DeviceManagement:DeviceInformation:1 --twin-id {twin_id} --properties '{\"manufacturer\": \"Microsoft\"}'"
+  - summary: Create a digital twin with component from existing (prior-created) models. Instantiate with property values.
+    syntax:
+      content: >-
+        az dt twin create -n {instance_name} --dtmi dtmi:example:Room;1 --twin-id {twin_id} --properties '{
+            "Temperature": 10.2,
+            "Thermostat": {
+                "$metadata": {},
+                "setPointTemp": 23.12
+            }
+        }'
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --dtmi --model-id -m
+    summary: 'Digital Twins model Id. Example: dtmi:example:Room;2.'
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --properties -p
+    summary: Initial property values for instantiating a digital twin or related components. Provide file path or inline JSON.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_delete
+  name: az dt twin delete
+  summary: Remove a digital twin. All relationships referencing this twin must already be deleted.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Remove a digital twin by Id.
+    syntax:
+      content: az dt twin delete -n {instance_name} --twin-id {twin_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_query
+  name: az dt twin query
+  summary: Query the digital twins of an instance. Allows traversing relationships and filtering by property values.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Query all digital twins in target instance and project all attributes. Also show cost in query units.
+    syntax:
+      content: az dt twin query -n {instance_name} -q "select * from digitaltwins" --show-cost
+  - summary: Query by model and project all attributes.
+    syntax:
+      content: az dt twin query -n {instance_name} -q "select * from digitaltwins T where IS_OF_MODEL(T, 'dtmi:example:Room;2')"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --query-command -q
+    summary: User query to be executed.
+    description: ''
+  - name: --cost --show-cost
+    parameterValueGroup: false, true
+    summary: Calculates and shows the query charge.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_show
+  name: az dt twin show
+  summary: Show the details of a digital twin.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show the details of a digital twin.
+    syntax:
+      content: az dt twin show -n {instance_name} --twin-id {twin_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_update
+  name: az dt twin update
+  summary: Update an instance digital twin via JSON patch specification.
+  description: Updates to property values and $model elements may happen in the same request. Operations are limited to add, replace and remove.
+  langs:
+  - azurecli
+  examples:
+  - summary: Update a digital twin via JSON patch specification.
+    syntax:
+      content: "az dt twin update -n {instance_name} --twin-id {twin_id} --json-patch '{\"op\":\"replace\", \"path\":\"/Temperature\", \"value\": 20.5}'"
+  - summary: Update a digital twin via JSON patch specification.
+    syntax:
+      content: >-
+        az dt twin update -n {instance_name} --twin-id {twin_id} --json-patch '[
+          {"op":"replace", "path":"/Temperature", "value": 20.5},
+          {"op":"add", "path":"/Areas", "value": ["ControlSystem"]}
+        ]'
+  - summary: Update a digital twin via JSON patch specification defined in a file.
+    syntax:
+      content: az dt twin update -n {instance_name} --twin-id {twin_id} --json-patch ./my/patch/document.json
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --json-patch --patch
+    summary: An update specification described by JSON-patch. Updates to property values and $model elements may happen in the same request. Operations are limited to add, replace and remove. Provide file path or inline JSON.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_twin_component
+  name: az dt twin component
+  summary: Show and update the digital twin components of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_component_show
+  name: az dt twin component show
+  summary: Show details of a digital twin component.
+- uid: ext_azure-iot_az_dt_twin_component_update
+  name: az dt twin component update
+  summary: Update a digital twin component via JSON patch specification.
+- uid: ext_azure-iot_az_dt_twin_create
+  name: az dt twin create
+  summary: Create a digital twin on an instance.
+- uid: ext_azure-iot_az_dt_twin_delete
+  name: az dt twin delete
+  summary: Remove a digital twin. All relationships referencing this twin must already be deleted.
+- uid: ext_azure-iot_az_dt_twin_query
+  name: az dt twin query
+  summary: Query the digital twins of an instance. Allows traversing relationships and filtering by property values.
+- uid: ext_azure-iot_az_dt_twin_relationship
+  name: az dt twin relationship
+  summary: Manage and configure the digital twin relationships of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_relationship_create
+  name: az dt twin relationship create
+  summary: Create a relationship between source and target digital twins.
+- uid: ext_azure-iot_az_dt_twin_relationship_delete
+  name: az dt twin relationship delete
+  summary: Delete a digital twin relationship on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_relationship_list
+  name: az dt twin relationship list
+  summary: List the relationships of a digital twin.
+- uid: ext_azure-iot_az_dt_twin_relationship_show
+  name: az dt twin relationship show
+  summary: Show details of a digital twin relationship.
+- uid: ext_azure-iot_az_dt_twin_relationship_update
+  name: az dt twin relationship update
+  summary: Updates the properties of a relationship between two digital twins via JSON patch specification.
+- uid: ext_azure-iot_az_dt_twin_show
+  name: az dt twin show
+  summary: Show the details of a digital twin.
+- uid: ext_azure-iot_az_dt_twin_telemetry
+  name: az dt twin telemetry
+  summary: Test and validate the event routes and endpoints of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_telemetry_send
+  name: az dt twin telemetry send
+  summary: Sends telemetry on behalf of a digital twin. If component path is provided the emitted telemetry is on behalf of the component.
+- uid: ext_azure-iot_az_dt_twin_update
+  name: az dt twin update
+  summary: Update an instance digital twin via JSON patch specification.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Manage and configure the digital twins of a Digital Twins instance.

--- a/2019-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/twin/component.yml
+++ b/2019-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/twin/component.yml
@@ -1,0 +1,100 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_twin_component
+  name: az dt twin component
+  summary: Show and update the digital twin components of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_twin_component_show
+  - ext_azure-iot_az_dt_twin_component_update
+- uid: ext_azure-iot_az_dt_twin_component_show
+  name: az dt twin component show
+  summary: Show details of a digital twin component.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show details of a digital twin component
+    syntax:
+      content: az dt twin component show -n {instance_name} --twin-id {twin_id} --component Thermostat
+  parameters:
+  - isRequired: true
+    name: --component
+    summary: The path to the DTDL component.
+    description: ''
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_component_update
+  name: az dt twin component update
+  summary: Update a digital twin component via JSON patch specification.
+  description: Updates to property values and $model elements may happen in the same request. Operations are limited to add, replace and remove.
+  langs:
+  - azurecli
+  examples:
+  - summary: Update a digital twin component via JSON patch specification.
+    syntax:
+      content: "az dt twin component update -n {instance_name} --twin-id {twin_id} --component {component_path} --json-patch '{\"op\":\"replace\", \"path\":\"/Temperature\", \"value\": 20.5}'"
+  - summary: Update a digital twin component via JSON patch specification.
+    syntax:
+      content: >-
+        az dt twin component update -n {instance_name} --twin-id {twin_id} --component {component_path} --json-patch '[
+          {"op":"replace", "path":"/Temperature", "value": 20.5},
+          {"op":"add", "path":"/Areas", "value": ["ControlSystem"]}
+        ]'
+  - summary: Update a digital twin component via JSON patch specification defined in a file.
+    syntax:
+      content: az dt twin component update -n {instance_name} --twin-id {twin_id} --component {component_path} --json-patch ./my/patch/document.json
+  parameters:
+  - isRequired: true
+    name: --component
+    summary: The path to the DTDL component.
+    description: ''
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --json-patch --patch
+    summary: An update specification described by JSON-patch. Updates to property values and $model elements may happen in the same request. Operations are limited to add, replace and remove. Provide file path or inline JSON.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_twin_component_show
+  name: az dt twin component show
+  summary: Show details of a digital twin component.
+- uid: ext_azure-iot_az_dt_twin_component_update
+  name: az dt twin component update
+  summary: Update a digital twin component via JSON patch specification.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Show and update the digital twin components of a Digital Twins instance.

--- a/2019-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/twin/relationship.yml
+++ b/2019-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/twin/relationship.yml
@@ -1,0 +1,216 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_twin_relationship
+  name: az dt twin relationship
+  summary: Manage and configure the digital twin relationships of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_twin_relationship_create
+  - ext_azure-iot_az_dt_twin_relationship_delete
+  - ext_azure-iot_az_dt_twin_relationship_list
+  - ext_azure-iot_az_dt_twin_relationship_show
+  - ext_azure-iot_az_dt_twin_relationship_update
+- uid: ext_azure-iot_az_dt_twin_relationship_create
+  name: az dt twin relationship create
+  summary: Create a relationship between source and target digital twins.
+  description: --properties can be inline JSON or file path.
+  langs:
+  - azurecli
+  examples:
+  - summary: Create a relationship between two digital twins.
+    syntax:
+      content: az dt twin relationship create -n {instance_name} --relationship-id {relationship_id} --relationship contains --source {source_twin_id} --target {target_twin_id}
+  - summary: Create a relationship with initialized properties between two digital twins.
+    syntax:
+      content: "az dt twin relationship create -n {instance_name} --relationship-id {relationship_id} --relationship contains --source {source_twin_id} --target {target_twin_id} --properties '{\"ownershipUser\": \"me\", \"ownershipDepartment\": \"Computer Science\"}'"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --kind --relationship
+    summary: "Relationship name or kind. For example: 'contains'."
+    description: ''
+  - isRequired: true
+    name: --relationship-id -r
+    summary: Relationship Id.
+    description: ''
+  - isRequired: true
+    name: --source --source-twin-id -s
+    summary: The source twin Id for a relationship.
+    description: ''
+  - isRequired: true
+    name: --target --target-twin-id -t
+    summary: The target twin Id for a relationship.
+    description: ''
+  - name: --properties -p
+    summary: Initial property values for instantiating a digital twin relationship. Provide file path or inline JSON.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_relationship_delete
+  name: az dt twin relationship delete
+  summary: Delete a digital twin relationship on a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Delete a digital twin relationship.
+    syntax:
+      content: az dt twin relationship delete -n {instance_name} --twin-id {twin_id} --relationship-id {relationship_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --relationship-id -r
+    summary: Relationship Id.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_relationship_list
+  name: az dt twin relationship list
+  summary: List the relationships of a digital twin.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List outgoing relationships of a digital twin.
+    syntax:
+      content: az dt twin relationship list -n {instance_name} --twin-id {twin_id}
+  - summary: List outgoing relationships of a digital twin and filter on relationship 'contains'
+    syntax:
+      content: az dt twin relationship list -n {instance_name} --twin-id {twin_id} --relationship contains
+  - summary: List incoming relationships of a digital twin.
+    syntax:
+      content: az dt twin relationship list -n {instance_name} --twin-id {twin_id} --incoming
+  - summary: List incoming relationships of a digital twin and filter on relationship 'contains'.
+    syntax:
+      content: az dt twin relationship list -n {instance_name} --twin-id {twin_id} --relationship contains --incoming
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --incoming
+    parameterValueGroup: false, true
+    summary: Retrieves all incoming relationships for a digital twin.
+    description: ''
+  - name: --kind --relationship
+    summary: Filter result by the kind of relationship.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_relationship_show
+  name: az dt twin relationship show
+  summary: Show details of a digital twin relationship.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show details of a digital twin relationship.
+    syntax:
+      content: az dt twin relationship show -n {instance_name} --twin-id {twin_id} --relationship-id {relationship_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --relationship-id -r
+    summary: Relationship Id.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_relationship_update
+  name: az dt twin relationship update
+  summary: Updates the properties of a relationship between two digital twins via JSON patch specification.
+  description: Operations are limited to add, replace and remove.
+  langs:
+  - azurecli
+  examples:
+  - summary: Update a digital twin relationship via JSON patch specification.
+    syntax:
+      content: "az dt twin relationship update -n {instance_name} --twin-id {twin_id} --relationship-id {relationship_id} --relationship contains --json-patch '{\"op\":\"replace\", \"path\":\"/Temperature\", \"value\": 20.5}'"
+  - summary: Update a digital twin relationship via JSON patch specification.
+    syntax:
+      content: >-
+        az dt twin relationship update -n {instance_name} --twin-id {twin_id} --relationship-id {relationship_id} --relationship contains --json-patch '[
+          {"op":"replace", "path":"/Temperature", "value": 20.5},
+          {"op":"add", "path":"/Areas", "value": ["ControlSystem"]}
+        ]'
+  - summary: Update a digital twin relationship via JSON patch specification defined in a file.
+    syntax:
+      content: az dt twin relationship update -n {instance_name} --twin-id {twin_id} --relationship-id {relationship_id} --relationship contains --json-patch ./my/patch/document.json
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --json-patch --patch
+    summary: An update specification described by JSON-patch. Updates to property values and $model elements may happen in the same request. Operations are limited to add, replace and remove. Provide file path or inline JSON.
+    description: ''
+  - isRequired: true
+    name: --relationship-id -r
+    summary: Relationship Id.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_twin_relationship_create
+  name: az dt twin relationship create
+  summary: Create a relationship between source and target digital twins.
+- uid: ext_azure-iot_az_dt_twin_relationship_delete
+  name: az dt twin relationship delete
+  summary: Delete a digital twin relationship on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_relationship_list
+  name: az dt twin relationship list
+  summary: List the relationships of a digital twin.
+- uid: ext_azure-iot_az_dt_twin_relationship_show
+  name: az dt twin relationship show
+  summary: Show details of a digital twin relationship.
+- uid: ext_azure-iot_az_dt_twin_relationship_update
+  name: az dt twin relationship update
+  summary: Updates the properties of a relationship between two digital twins via JSON patch specification.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Manage and configure the digital twin relationships of a Digital Twins instance.

--- a/2019-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/twin/telemetry.yml
+++ b/2019-03-01-hybrid/docs-ref-autogen/ext/azure-iot/dt/twin/telemetry.yml
@@ -1,0 +1,61 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_twin_telemetry
+  name: az dt twin telemetry
+  summary: Test and validate the event routes and endpoints of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_twin_telemetry_send
+- uid: ext_azure-iot_az_dt_twin_telemetry_send
+  name: az dt twin telemetry send
+  summary: Sends telemetry on behalf of a digital twin. If component path is provided the emitted telemetry is on behalf of the component.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Send twin telemetry
+    syntax:
+      content: az dt twin telemetry send -n {instance_name} --twin-id {twin_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --component
+    summary: The path to the DTDL component. If set, telemetry will be emitted on behalf of the component.
+    description: ''
+  - name: --dt-id
+    summary: A unique message identifier (in the scope of the digital twin id) that is commonly used for de-duplicating messages. If no value is provided a GUID is automatically generated.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --telemetry
+    summary: 'Inline telemetry JSON or file path to telemetry JSON. Default payload is an empty object: {}.'
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_twin_telemetry_send
+  name: az dt twin telemetry send
+  summary: Sends telemetry on behalf of a digital twin. If component path is provided the emitted telemetry is on behalf of the component.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Test and validate the event routes and endpoints of a Digital Twins instance.

--- a/2019-03-01-hybrid/docs-ref-autogen/ext/azure-iot/index.yml
+++ b/2019-03-01-hybrid/docs-ref-autogen/ext/azure-iot/index.yml
@@ -8,6 +8,9 @@ items:
   - azurecli
   children: []
 commands:
+- uid: ext_azure-iot_az_dt
+  name: az dt
+  summary: Manage Azure Digital Twins (ADT) solutions & infrastructure.
 - uid: ext_azure-iot_az_iot
   name: az iot
   summary: Manage Internet of Things (IoT) assets. Augmented with the IoT extension.

--- a/latest/docs-ref-autogen/ext/azure-iot/dt.yml
+++ b/latest/docs-ref-autogen/ext/azure-iot/dt.yml
@@ -1,0 +1,253 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt
+  name: az dt
+  summary: Manage Azure Digital Twins (ADT) solutions & infrastructure.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_create
+  - ext_azure-iot_az_dt_delete
+  - ext_azure-iot_az_dt_list
+  - ext_azure-iot_az_dt_show
+- uid: ext_azure-iot_az_dt_create
+  name: az dt create
+  summary: Create a new Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Create instance in target resource group with default location.
+    syntax:
+      content: az dt create -n {instance_name} -g {resouce_group} -l eastus2euap
+  - summary: Create instance in target resource group with specified location and tags.
+    syntax:
+      content: az dt create -n {instance_name} -g {resouce_group} -l westcentralus --tags "a=b;c=d"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --location -l
+    summary: Digital Twins instance location. You can configure the default location using `az configure --defaults location=&lt;name&gt;`.
+    description: ''
+  - isRequired: true
+    name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --tags
+    summary: 'Digital Twins instance tags. Property bag in key-value pairs with the following format: a=b;c=d.'
+    description: ''
+- uid: ext_azure-iot_az_dt_delete
+  name: az dt delete
+  summary: Delete an existing Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Delete an arbitrary instance.
+    syntax:
+      content: az dt delete -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_list
+  name: az dt list
+  summary: List the collection of Digital Twins instances by subscription or resource group.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List all instances in the current subscription.
+    syntax:
+      content: az dt list
+  - summary: List all instances in target resource group and output in table format.
+    syntax:
+      content: az dt list -g {resource_group} --output table
+  - summary: List all instances in subscription that meet a condition.
+    syntax:
+      content: az dt list --query "[?contains(name, 'Production')]"
+  - summary: Count instances that meet condition.
+    syntax:
+      content: az dt list --query "length([?contains(name, 'Production')])"
+  parameters:
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_show
+  name: az dt show
+  summary: Show an existing Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show an instance.
+    syntax:
+      content: az dt show -n {instance_name}
+  - summary: Show an instance and project certain properties.
+    syntax:
+      content: az dt show -n {instance_name} --query "{Endpoint:hostName, Location:location}"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_create
+  name: az dt create
+  summary: Create a new Digital Twins instance.
+- uid: ext_azure-iot_az_dt_delete
+  name: az dt delete
+  summary: Delete an existing Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint
+  name: az dt endpoint
+  summary: Manage and configure Digital Twins instance endpoints.
+- uid: ext_azure-iot_az_dt_endpoint_create
+  name: az dt endpoint create
+  summary: Add egress endpoints to a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_create_eventgrid
+  name: az dt endpoint create eventgrid
+  summary: Adds an EventGrid Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_eventhub
+  name: az dt endpoint create eventhub
+  summary: Adds an EventHub endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_servicebus
+  name: az dt endpoint create servicebus
+  summary: Adds a ServiceBus Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_delete
+  name: az dt endpoint delete
+  summary: Remove an endpoint from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_list
+  name: az dt endpoint list
+  summary: List all egress endpoints configured on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_show
+  name: az dt endpoint show
+  summary: Show details of an endpoint configured on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_list
+  name: az dt list
+  summary: List the collection of Digital Twins instances by subscription or resource group.
+- uid: ext_azure-iot_az_dt_model
+  name: az dt model
+  summary: Manage DTDL models and definitions on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_model_create
+  name: az dt model create
+  summary: Uploads one or more models. When any error occurs, no models are uploaded.
+- uid: ext_azure-iot_az_dt_model_delete
+  name: az dt model delete
+  summary: Delete a model. A model can only be deleted if no other models reference it.
+- uid: ext_azure-iot_az_dt_model_list
+  name: az dt model list
+  summary: List model metadata, definitions and dependencies.
+- uid: ext_azure-iot_az_dt_model_show
+  name: az dt model show
+  summary: Retrieve a target model or model definition.
+- uid: ext_azure-iot_az_dt_model_update
+  name: az dt model update
+  summary: Updates the metadata for a model. Currently a model can only be decommisioned.
+- uid: ext_azure-iot_az_dt_role_assignment
+  name: az dt role-assignment
+  summary: Manage RBAC role assignments for a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_role_assignment_create
+  name: az dt role-assignment create
+  summary: Assign a user, group or service principal to a role against a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_role_assignment_delete
+  name: az dt role-assignment delete
+  summary: Remove a user, group or service principal role assignment from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_role_assignment_list
+  name: az dt role-assignment list
+  summary: List the existing role assignments of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route
+  name: az dt route
+  summary: Manage and configure event routes.
+- uid: ext_azure-iot_az_dt_route_create
+  name: az dt route create
+  summary: Add an event route to a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_delete
+  name: az dt route delete
+  summary: Remove an event route from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_list
+  name: az dt route list
+  summary: List the configured event routes of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_show
+  name: az dt route show
+  summary: Show details of an event route configured on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_show
+  name: az dt show
+  summary: Show an existing Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin
+  name: az dt twin
+  summary: Manage and configure the digital twins of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_component
+  name: az dt twin component
+  summary: Show and update the digital twin components of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_component_show
+  name: az dt twin component show
+  summary: Show details of a digital twin component.
+- uid: ext_azure-iot_az_dt_twin_component_update
+  name: az dt twin component update
+  summary: Update a digital twin component via JSON patch specification.
+- uid: ext_azure-iot_az_dt_twin_create
+  name: az dt twin create
+  summary: Create a digital twin on an instance.
+- uid: ext_azure-iot_az_dt_twin_delete
+  name: az dt twin delete
+  summary: Remove a digital twin. All relationships referencing this twin must already be deleted.
+- uid: ext_azure-iot_az_dt_twin_query
+  name: az dt twin query
+  summary: Query the digital twins of an instance. Allows traversing relationships and filtering by property values.
+- uid: ext_azure-iot_az_dt_twin_relationship
+  name: az dt twin relationship
+  summary: Manage and configure the digital twin relationships of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_relationship_create
+  name: az dt twin relationship create
+  summary: Create a relationship between source and target digital twins.
+- uid: ext_azure-iot_az_dt_twin_relationship_delete
+  name: az dt twin relationship delete
+  summary: Delete a digital twin relationship on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_relationship_list
+  name: az dt twin relationship list
+  summary: List the relationships of a digital twin.
+- uid: ext_azure-iot_az_dt_twin_relationship_show
+  name: az dt twin relationship show
+  summary: Show details of a digital twin relationship.
+- uid: ext_azure-iot_az_dt_twin_relationship_update
+  name: az dt twin relationship update
+  summary: Updates the properties of a relationship between two digital twins via JSON patch specification.
+- uid: ext_azure-iot_az_dt_twin_show
+  name: az dt twin show
+  summary: Show the details of a digital twin.
+- uid: ext_azure-iot_az_dt_twin_telemetry
+  name: az dt twin telemetry
+  summary: Test and validate the event routes and endpoints of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_telemetry_send
+  name: az dt twin telemetry send
+  summary: Sends telemetry on behalf of a digital twin. If component path is provided the emitted telemetry is on behalf of the component.
+- uid: ext_azure-iot_az_dt_twin_update
+  name: az dt twin update
+  summary: Update an instance digital twin via JSON patch specification.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Manage Azure Digital Twins (ADT) solutions & infrastructure.

--- a/latest/docs-ref-autogen/ext/azure-iot/dt/endpoint.yml
+++ b/latest/docs-ref-autogen/ext/azure-iot/dt/endpoint.yml
@@ -1,0 +1,112 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_endpoint
+  name: az dt endpoint
+  summary: Manage and configure Digital Twins instance endpoints.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_endpoint_delete
+  - ext_azure-iot_az_dt_endpoint_list
+  - ext_azure-iot_az_dt_endpoint_show
+- uid: ext_azure-iot_az_dt_endpoint_delete
+  name: az dt endpoint delete
+  summary: Remove an endpoint from a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Remove an endpoint from an instance.
+    syntax:
+      content: az dt endpoint delete -n {instance_name} --endpoint-name {endpoint_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_endpoint_list
+  name: az dt endpoint list
+  summary: List all egress endpoints configured on a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List all egress endpoints configured on an instance.
+    syntax:
+      content: az dt endpoint list -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_endpoint_show
+  name: az dt endpoint show
+  summary: Show details of an endpoint configured on a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show a desired endpoint by name on an instance.
+    syntax:
+      content: az dt endpoint show -n {instance_name} --endpoint-name {endpoint_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_endpoint_create
+  name: az dt endpoint create
+  summary: Add egress endpoints to a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_create_eventgrid
+  name: az dt endpoint create eventgrid
+  summary: Adds an EventGrid Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_eventhub
+  name: az dt endpoint create eventhub
+  summary: Adds an EventHub endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_servicebus
+  name: az dt endpoint create servicebus
+  summary: Adds a ServiceBus Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_delete
+  name: az dt endpoint delete
+  summary: Remove an endpoint from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_list
+  name: az dt endpoint list
+  summary: List all egress endpoints configured on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_endpoint_show
+  name: az dt endpoint show
+  summary: Show details of an endpoint configured on a Digital Twins instance.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Manage and configure Digital Twins instance endpoints.

--- a/latest/docs-ref-autogen/ext/azure-iot/dt/endpoint/create.yml
+++ b/latest/docs-ref-autogen/ext/azure-iot/dt/endpoint/create.yml
@@ -1,0 +1,153 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_endpoint_create
+  name: az dt endpoint create
+  summary: Add egress endpoints to a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_endpoint_create_eventgrid
+  - ext_azure-iot_az_dt_endpoint_create_eventhub
+  - ext_azure-iot_az_dt_endpoint_create_servicebus
+- uid: ext_azure-iot_az_dt_endpoint_create_eventgrid
+  name: az dt endpoint create eventgrid
+  summary: Adds an EventGrid Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Adds an EventGrid Topic endpoint to a target instance.
+    syntax:
+      content: az dt endpoint create eventgrid --endpoint-name {endpoint_name} --eventgrid-resource-group {eventgrid_resource_group} --eventgrid-topic {eventgrid_topic_name} -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --tags
+    summary: 'Digital Twins endpoint tags. Property bag in key-value pairs with the following format: a=b;c=d.'
+    description: ''
+  - isRequired: true
+    name: --egg --eventgrid-resource-group
+    summary: Name of EventGrid Topic resource group.
+    description: ''
+  - isRequired: true
+    name: --egt --eventgrid-topic
+    summary: Name of EventGrid Topic to integrate with.
+    description: ''
+- uid: ext_azure-iot_az_dt_endpoint_create_eventhub
+  name: az dt endpoint create eventhub
+  summary: Adds an EventHub endpoint to a Digital Twins instance. Requires pre-created resource.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Adds an EventHub endpoint to a target instance.
+    syntax:
+      content: az dt endpoint create eventhub --endpoint-name {endpoint_name} --eventhub-resource-group {eventhub_resource_group} --eventhub-namespace {eventhub_namespace} --eventhub {eventhub_name} --eventhub-policy {eventhub_policy} -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --tags
+    summary: 'Digital Twins endpoint tags. Property bag in key-value pairs with the following format: a=b;c=d.'
+    description: ''
+  - isRequired: true
+    name: --eh --eventhub
+    summary: Name of EventHub to integrate with.
+    description: ''
+  - isRequired: true
+    name: --ehg --eventhub-resource-group
+    summary: Name of EventHub resource group.
+    description: ''
+  - isRequired: true
+    name: --ehn --eventhub-namespace
+    summary: EventHub Namespace identifier.
+    description: ''
+  - isRequired: true
+    name: --ehp --eventhub-policy
+    summary: EventHub policy to use for endpoint configuration.
+    description: ''
+- uid: ext_azure-iot_az_dt_endpoint_create_servicebus
+  name: az dt endpoint create servicebus
+  summary: Adds a ServiceBus Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Adds a ServiceBus Topic endpoint to a target instance.
+    syntax:
+      content: az dt endpoint create servicebus --endpoint-name {endpoint_name} --servicebus-resource-group {servicebus_resource_group} --servicebus-namespace {servicebus_namespace} --servicebus-topic {servicebus_topic_name} --servicebus-policy {servicebus_policy} -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --tags
+    summary: 'Digital Twins endpoint tags. Property bag in key-value pairs with the following format: a=b;c=d.'
+    description: ''
+  - isRequired: true
+    name: --sbg --servicebus-resource-group
+    summary: Name of ServiceBus resource group.
+    description: ''
+  - isRequired: true
+    name: --sbn --servicebus-namespace
+    summary: ServiceBus Namespace identifier.
+    description: ''
+  - isRequired: true
+    name: --sbp --servicebus-policy
+    summary: ServiceBus Topic policy to use for endpoint configuration.
+    description: ''
+  - isRequired: true
+    name: --sbt --servicebus-topic
+    summary: Name of ServiceBus Topic to integrate with.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_endpoint_create_eventgrid
+  name: az dt endpoint create eventgrid
+  summary: Adds an EventGrid Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_eventhub
+  name: az dt endpoint create eventhub
+  summary: Adds an EventHub endpoint to a Digital Twins instance. Requires pre-created resource.
+- uid: ext_azure-iot_az_dt_endpoint_create_servicebus
+  name: az dt endpoint create servicebus
+  summary: Adds a ServiceBus Topic endpoint to a Digital Twins instance. Requires pre-created resource.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Add egress endpoints to a Digital Twins instance.

--- a/latest/docs-ref-autogen/ext/azure-iot/dt/model.yml
+++ b/latest/docs-ref-autogen/ext/azure-iot/dt/model.yml
@@ -1,0 +1,181 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_model
+  name: az dt model
+  summary: Manage DTDL models and definitions on a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_model_create
+  - ext_azure-iot_az_dt_model_delete
+  - ext_azure-iot_az_dt_model_list
+  - ext_azure-iot_az_dt_model_show
+  - ext_azure-iot_az_dt_model_update
+- uid: ext_azure-iot_az_dt_model_create
+  name: az dt model create
+  summary: Uploads one or more models. When any error occurs, no models are uploaded.
+  description: --models can be inline json or file path.
+  langs:
+  - azurecli
+  examples:
+  - summary: Bulk upload all .json or .dtdl model files from a target directory. Model processing is recursive.
+    syntax:
+      content: az dt model create -n {instance_name} --from-directory {directory_path}
+  - summary: Upload model json inline or from file path.
+    syntax:
+      content: az dt model create -n {instance_name} --models {file_path_or_inline_json}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --fd --from-directory
+    summary: The directory JSON model files will be parsed from.
+    description: ''
+  - name: --models
+    summary: Inline model JSON or file path to model JSON.
+    description: ''
+- uid: ext_azure-iot_az_dt_model_delete
+  name: az dt model delete
+  summary: Delete a model. A model can only be deleted if no other models reference it.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Delete a target model.
+    syntax:
+      content: az dt model delete -n {instance_name} --dtmi "dtmi:example:Floor;1"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --dtmi --model-id -m
+    summary: 'Digital Twins model Id. Example: dtmi:example:Room;2.'
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_model_list
+  name: az dt model list
+  summary: List model metadata, definitions and dependencies.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List model metadata
+    syntax:
+      content: az dt model list -n {instance_name}
+  - summary: List model definitions
+    syntax:
+      content: az dt model list -n {instance_name} --definition
+  - summary: List dependencies of particular pre-existing model(s). Space seperate dtmi values.
+    syntax:
+      content: az dt model list -n {instance_name} --dependencies-for {model_id0} {model_id1}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --def --definition
+    parameterValueGroup: false, true
+    summary: The operation will retrieve the model definition.
+    description: ''
+  - name: --dependencies-for
+    summary: The set of models which will have their dependencies retrieved. If omitted, all models are retrieved. Format is a whitespace separated list.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_model_show
+  name: az dt model show
+  summary: Retrieve a target model or model definition.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show model meta data
+    syntax:
+      content: az dt model show -n {instance_name} --dtmi "dtmi:example:Floor;1"
+  - summary: Show model meta data and definition
+    syntax:
+      content: az dt model show -n {instance_name} --dtmi "dtmi:example:Floor;1" --definition
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --dtmi --model-id -m
+    summary: 'Digital Twins model Id. Example: dtmi:example:Room;2.'
+    description: ''
+  - name: --def --definition
+    parameterValueGroup: false, true
+    summary: The operation will retrieve the model definition.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_model_update
+  name: az dt model update
+  summary: Updates the metadata for a model. Currently a model can only be decommisioned.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Decommision a target model
+    syntax:
+      content: az dt model update -n {instance_name} --dtmi "dtmi:example:Floor;1" --decommission
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --dtmi --model-id -m
+    summary: 'Digital Twins model Id. Example: dtmi:example:Room;2.'
+    description: ''
+  - name: --decommission
+    parameterValueGroup: false, true
+    summary: Indicates intent to decommission a target model.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_model_create
+  name: az dt model create
+  summary: Uploads one or more models. When any error occurs, no models are uploaded.
+- uid: ext_azure-iot_az_dt_model_delete
+  name: az dt model delete
+  summary: Delete a model. A model can only be deleted if no other models reference it.
+- uid: ext_azure-iot_az_dt_model_list
+  name: az dt model list
+  summary: List model metadata, definitions and dependencies.
+- uid: ext_azure-iot_az_dt_model_show
+  name: az dt model show
+  summary: Retrieve a target model or model definition.
+- uid: ext_azure-iot_az_dt_model_update
+  name: az dt model update
+  summary: Updates the metadata for a model. Currently a model can only be decommisioned.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Manage DTDL models and definitions on a Digital Twins instance.

--- a/latest/docs-ref-autogen/ext/azure-iot/dt/role-assignment.yml
+++ b/latest/docs-ref-autogen/ext/azure-iot/dt/role-assignment.yml
@@ -1,0 +1,141 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_role_assignment
+  name: az dt role-assignment
+  summary: Manage RBAC role assignments for a Digital Twins instance.
+  description: >-
+    Note that in order to perform role assignments, the logged in principal needs permissions
+
+    such as Owner or User Access Administrator at the assigned scope.
+
+
+    This command group is provided for convenience. For more complex role assignment scenarios
+
+    use the 'az role assignment' command group.
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_role_assignment_create
+  - ext_azure-iot_az_dt_role_assignment_delete
+  - ext_azure-iot_az_dt_role_assignment_list
+- uid: ext_azure-iot_az_dt_role_assignment_create
+  name: az dt role-assignment create
+  summary: Assign a user, group or service principal to a role against a Digital Twins instance.
+  description: Note that in order to perform role assignments, the logged in principal needs permissions such as Owner or User Access Administrator at the assigned scope.
+  langs:
+  - azurecli
+  examples:
+  - summary: Assign a user (by email) the built-in Digital Twins Owner role against a target instance.
+    syntax:
+      content: az dt role-assignment create -n {instance_name} --assignee "owneruser@microsoft.com" --role "Azure Digital Twins Owner (Preview)"
+  - summary: Assign a user (by object Id) the built-in Digital Twins Reader role against a target instance.
+    syntax:
+      content: az dt role-assignment create -n {instance_name} --assignee "97a89267-0966-4054-a156-b7d86ef8e216" --role "Azure Digital Twins Reader (Preview)"
+  - summary: Assign a service principal a custom role against a target instance.
+    syntax:
+      content: az dt role-assignment create -n {instance_name} --assignee {service_principal_name_or_id} --role {role_name_or_id}
+  parameters:
+  - isRequired: true
+    name: --assignee
+    summary: 'Represent a user, group, or service principal. supported format: object id, user sign-in name, or service principal name.'
+    description: ''
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --role
+    summary: Role name or Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_role_assignment_delete
+  name: az dt role-assignment delete
+  summary: Remove a user, group or service principal role assignment from a Digital Twins instance.
+  description: Note that in order to perform role assignments, the logged in principal needs permissions such as Owner or User Access Administrator at the assigned scope.
+  langs:
+  - azurecli
+  examples:
+  - summary: Remove a user from a specific role assignment of a Digital Twins instance.
+    syntax:
+      content: az dt role-assignment delete -n {instance_name} --assignee "removeuser@microsoft.com" --role "Azure Digital Twins Reader (Preview)"
+  - summary: Remove a user from all assigned roles of a Digital Twins instance.
+    syntax:
+      content: az dt role-assignment delete -n {instance_name} --assignee "removeuser@microsoft.com"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --assignee
+    summary: 'Represent a user, group, or service principal. supported format: object id, user sign-in name, or service principal name.'
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --role
+    summary: Role name or Id.
+    description: ''
+- uid: ext_azure-iot_az_dt_role_assignment_list
+  name: az dt role-assignment list
+  summary: List the existing role assignments of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List the role assignments on a target instance.
+    syntax:
+      content: az dt role-assignment list -n {instance_name}
+  - summary: List the role assignments on a target instance and filter by role.
+    syntax:
+      content: az dt role-assignment list -n {instance_name} --role {role_name_or_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --include-inherited
+    parameterValueGroup: false, true
+    summary: Include assignments applied on parent scopes.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --role
+    summary: Role name or Id.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_role_assignment_create
+  name: az dt role-assignment create
+  summary: Assign a user, group or service principal to a role against a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_role_assignment_delete
+  name: az dt role-assignment delete
+  summary: Remove a user, group or service principal role assignment from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_role_assignment_list
+  name: az dt role-assignment list
+  summary: List the existing role assignments of a Digital Twins instance.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: >-
+  Note that in order to perform role assignments, the logged in principal needs permissions
+
+  such as Owner or User Access Administrator at the assigned scope.
+
+
+  This command group is provided for convenience. For more complex role assignment scenarios
+
+  use the 'az role assignment' command group.

--- a/latest/docs-ref-autogen/ext/azure-iot/dt/route.yml
+++ b/latest/docs-ref-autogen/ext/azure-iot/dt/route.yml
@@ -1,0 +1,137 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_route
+  name: az dt route
+  summary: Manage and configure event routes.
+  description: Note that an endpoint must first be configred before adding an event route.
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_route_create
+  - ext_azure-iot_az_dt_route_delete
+  - ext_azure-iot_az_dt_route_list
+  - ext_azure-iot_az_dt_route_show
+- uid: ext_azure-iot_az_dt_route_create
+  name: az dt route create
+  summary: Add an event route to a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Adds an event route for an existing endpoint on target instance with default filter of "true".
+    syntax:
+      content: az dt route create -n {instance_name} --endpoint-name {endpoint_name} --route-name {route_name}
+  - summary: Adds an event route for an existing endpoint on target instance with custom filter.
+    syntax:
+      content: az dt route create -n {instance_name} --endpoint-name {endpoint_name} --route-name {route_name} --filter "type = 'Microsoft.DigitalTwins.Twin.Create'"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --en --endpoint-name
+    summary: Endpoint name.
+    description: ''
+  - isRequired: true
+    name: --rn --route-name
+    summary: Event route name.
+    description: ''
+  - name: --filter
+    defaultValue: "true"
+    summary: Event route filter.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_route_delete
+  name: az dt route delete
+  summary: Remove an event route from a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Remove an event route from a target instance.
+    syntax:
+      content: az dt route delete -n {instance_name} --route-name {route_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --rn --route-name
+    summary: Event route name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_route_list
+  name: az dt route list
+  summary: List the configured event routes of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List configured event routes of a target instance.
+    syntax:
+      content: az dt route list -n {instance_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_route_show
+  name: az dt route show
+  summary: Show details of an event route configured on a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show an event route on a target instance.
+    syntax:
+      content: az dt route show -n {instance_name} --route-name {route_name}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --rn --route-name
+    summary: Event route name.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_route_create
+  name: az dt route create
+  summary: Add an event route to a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_delete
+  name: az dt route delete
+  summary: Remove an event route from a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_list
+  name: az dt route list
+  summary: List the configured event routes of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_route_show
+  name: az dt route show
+  summary: Show details of an event route configured on a Digital Twins instance.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Note that an endpoint must first be configred before adding an event route.

--- a/latest/docs-ref-autogen/ext/azure-iot/dt/twin.yml
+++ b/latest/docs-ref-autogen/ext/azure-iot/dt/twin.yml
@@ -1,0 +1,230 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_twin
+  name: az dt twin
+  summary: Manage and configure the digital twins of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_twin_create
+  - ext_azure-iot_az_dt_twin_delete
+  - ext_azure-iot_az_dt_twin_query
+  - ext_azure-iot_az_dt_twin_show
+  - ext_azure-iot_az_dt_twin_update
+- uid: ext_azure-iot_az_dt_twin_create
+  name: az dt twin create
+  summary: Create a digital twin on an instance.
+  description: --properties can be inline JSON or file path.
+  langs:
+  - azurecli
+  examples:
+  - summary: Create a digital twin from an existing (prior-created) model.
+    syntax:
+      content: az dt twin create -n {instance_name} --dtmi urn:azureiot:DeviceManagement:DeviceInformation:1 --twin-id {twin_id}
+  - summary: Create a digital twin from an existing (prior-created) model. Instantiate with property values.
+    syntax:
+      content: "az dt twin create -n {instance_name} --dtmi urn:azureiot:DeviceManagement:DeviceInformation:1 --twin-id {twin_id} --properties '{\"manufacturer\": \"Microsoft\"}'"
+  - summary: Create a digital twin with component from existing (prior-created) models. Instantiate with property values.
+    syntax:
+      content: >-
+        az dt twin create -n {instance_name} --dtmi dtmi:example:Room;1 --twin-id {twin_id} --properties '{
+            "Temperature": 10.2,
+            "Thermostat": {
+                "$metadata": {},
+                "setPointTemp": 23.12
+            }
+        }'
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --dtmi --model-id -m
+    summary: 'Digital Twins model Id. Example: dtmi:example:Room;2.'
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --properties -p
+    summary: Initial property values for instantiating a digital twin or related components. Provide file path or inline JSON.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_delete
+  name: az dt twin delete
+  summary: Remove a digital twin. All relationships referencing this twin must already be deleted.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Remove a digital twin by Id.
+    syntax:
+      content: az dt twin delete -n {instance_name} --twin-id {twin_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_query
+  name: az dt twin query
+  summary: Query the digital twins of an instance. Allows traversing relationships and filtering by property values.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Query all digital twins in target instance and project all attributes. Also show cost in query units.
+    syntax:
+      content: az dt twin query -n {instance_name} -q "select * from digitaltwins" --show-cost
+  - summary: Query by model and project all attributes.
+    syntax:
+      content: az dt twin query -n {instance_name} -q "select * from digitaltwins T where IS_OF_MODEL(T, 'dtmi:example:Room;2')"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --query-command -q
+    summary: User query to be executed.
+    description: ''
+  - name: --cost --show-cost
+    parameterValueGroup: false, true
+    summary: Calculates and shows the query charge.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_show
+  name: az dt twin show
+  summary: Show the details of a digital twin.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show the details of a digital twin.
+    syntax:
+      content: az dt twin show -n {instance_name} --twin-id {twin_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_update
+  name: az dt twin update
+  summary: Update an instance digital twin via JSON patch specification.
+  description: Updates to property values and $model elements may happen in the same request. Operations are limited to add, replace and remove.
+  langs:
+  - azurecli
+  examples:
+  - summary: Update a digital twin via JSON patch specification.
+    syntax:
+      content: "az dt twin update -n {instance_name} --twin-id {twin_id} --json-patch '{\"op\":\"replace\", \"path\":\"/Temperature\", \"value\": 20.5}'"
+  - summary: Update a digital twin via JSON patch specification.
+    syntax:
+      content: >-
+        az dt twin update -n {instance_name} --twin-id {twin_id} --json-patch '[
+          {"op":"replace", "path":"/Temperature", "value": 20.5},
+          {"op":"add", "path":"/Areas", "value": ["ControlSystem"]}
+        ]'
+  - summary: Update a digital twin via JSON patch specification defined in a file.
+    syntax:
+      content: az dt twin update -n {instance_name} --twin-id {twin_id} --json-patch ./my/patch/document.json
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --json-patch --patch
+    summary: An update specification described by JSON-patch. Updates to property values and $model elements may happen in the same request. Operations are limited to add, replace and remove. Provide file path or inline JSON.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_twin_component
+  name: az dt twin component
+  summary: Show and update the digital twin components of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_component_show
+  name: az dt twin component show
+  summary: Show details of a digital twin component.
+- uid: ext_azure-iot_az_dt_twin_component_update
+  name: az dt twin component update
+  summary: Update a digital twin component via JSON patch specification.
+- uid: ext_azure-iot_az_dt_twin_create
+  name: az dt twin create
+  summary: Create a digital twin on an instance.
+- uid: ext_azure-iot_az_dt_twin_delete
+  name: az dt twin delete
+  summary: Remove a digital twin. All relationships referencing this twin must already be deleted.
+- uid: ext_azure-iot_az_dt_twin_query
+  name: az dt twin query
+  summary: Query the digital twins of an instance. Allows traversing relationships and filtering by property values.
+- uid: ext_azure-iot_az_dt_twin_relationship
+  name: az dt twin relationship
+  summary: Manage and configure the digital twin relationships of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_relationship_create
+  name: az dt twin relationship create
+  summary: Create a relationship between source and target digital twins.
+- uid: ext_azure-iot_az_dt_twin_relationship_delete
+  name: az dt twin relationship delete
+  summary: Delete a digital twin relationship on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_relationship_list
+  name: az dt twin relationship list
+  summary: List the relationships of a digital twin.
+- uid: ext_azure-iot_az_dt_twin_relationship_show
+  name: az dt twin relationship show
+  summary: Show details of a digital twin relationship.
+- uid: ext_azure-iot_az_dt_twin_relationship_update
+  name: az dt twin relationship update
+  summary: Updates the properties of a relationship between two digital twins via JSON patch specification.
+- uid: ext_azure-iot_az_dt_twin_show
+  name: az dt twin show
+  summary: Show the details of a digital twin.
+- uid: ext_azure-iot_az_dt_twin_telemetry
+  name: az dt twin telemetry
+  summary: Test and validate the event routes and endpoints of a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_telemetry_send
+  name: az dt twin telemetry send
+  summary: Sends telemetry on behalf of a digital twin. If component path is provided the emitted telemetry is on behalf of the component.
+- uid: ext_azure-iot_az_dt_twin_update
+  name: az dt twin update
+  summary: Update an instance digital twin via JSON patch specification.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Manage and configure the digital twins of a Digital Twins instance.

--- a/latest/docs-ref-autogen/ext/azure-iot/dt/twin/component.yml
+++ b/latest/docs-ref-autogen/ext/azure-iot/dt/twin/component.yml
@@ -1,0 +1,100 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_twin_component
+  name: az dt twin component
+  summary: Show and update the digital twin components of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_twin_component_show
+  - ext_azure-iot_az_dt_twin_component_update
+- uid: ext_azure-iot_az_dt_twin_component_show
+  name: az dt twin component show
+  summary: Show details of a digital twin component.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show details of a digital twin component
+    syntax:
+      content: az dt twin component show -n {instance_name} --twin-id {twin_id} --component Thermostat
+  parameters:
+  - isRequired: true
+    name: --component
+    summary: The path to the DTDL component.
+    description: ''
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_component_update
+  name: az dt twin component update
+  summary: Update a digital twin component via JSON patch specification.
+  description: Updates to property values and $model elements may happen in the same request. Operations are limited to add, replace and remove.
+  langs:
+  - azurecli
+  examples:
+  - summary: Update a digital twin component via JSON patch specification.
+    syntax:
+      content: "az dt twin component update -n {instance_name} --twin-id {twin_id} --component {component_path} --json-patch '{\"op\":\"replace\", \"path\":\"/Temperature\", \"value\": 20.5}'"
+  - summary: Update a digital twin component via JSON patch specification.
+    syntax:
+      content: >-
+        az dt twin component update -n {instance_name} --twin-id {twin_id} --component {component_path} --json-patch '[
+          {"op":"replace", "path":"/Temperature", "value": 20.5},
+          {"op":"add", "path":"/Areas", "value": ["ControlSystem"]}
+        ]'
+  - summary: Update a digital twin component via JSON patch specification defined in a file.
+    syntax:
+      content: az dt twin component update -n {instance_name} --twin-id {twin_id} --component {component_path} --json-patch ./my/patch/document.json
+  parameters:
+  - isRequired: true
+    name: --component
+    summary: The path to the DTDL component.
+    description: ''
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --json-patch --patch
+    summary: An update specification described by JSON-patch. Updates to property values and $model elements may happen in the same request. Operations are limited to add, replace and remove. Provide file path or inline JSON.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_twin_component_show
+  name: az dt twin component show
+  summary: Show details of a digital twin component.
+- uid: ext_azure-iot_az_dt_twin_component_update
+  name: az dt twin component update
+  summary: Update a digital twin component via JSON patch specification.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Show and update the digital twin components of a Digital Twins instance.

--- a/latest/docs-ref-autogen/ext/azure-iot/dt/twin/relationship.yml
+++ b/latest/docs-ref-autogen/ext/azure-iot/dt/twin/relationship.yml
@@ -1,0 +1,216 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_twin_relationship
+  name: az dt twin relationship
+  summary: Manage and configure the digital twin relationships of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_twin_relationship_create
+  - ext_azure-iot_az_dt_twin_relationship_delete
+  - ext_azure-iot_az_dt_twin_relationship_list
+  - ext_azure-iot_az_dt_twin_relationship_show
+  - ext_azure-iot_az_dt_twin_relationship_update
+- uid: ext_azure-iot_az_dt_twin_relationship_create
+  name: az dt twin relationship create
+  summary: Create a relationship between source and target digital twins.
+  description: --properties can be inline JSON or file path.
+  langs:
+  - azurecli
+  examples:
+  - summary: Create a relationship between two digital twins.
+    syntax:
+      content: az dt twin relationship create -n {instance_name} --relationship-id {relationship_id} --relationship contains --source {source_twin_id} --target {target_twin_id}
+  - summary: Create a relationship with initialized properties between two digital twins.
+    syntax:
+      content: "az dt twin relationship create -n {instance_name} --relationship-id {relationship_id} --relationship contains --source {source_twin_id} --target {target_twin_id} --properties '{\"ownershipUser\": \"me\", \"ownershipDepartment\": \"Computer Science\"}'"
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --kind --relationship
+    summary: "Relationship name or kind. For example: 'contains'."
+    description: ''
+  - isRequired: true
+    name: --relationship-id -r
+    summary: Relationship Id.
+    description: ''
+  - isRequired: true
+    name: --source --source-twin-id -s
+    summary: The source twin Id for a relationship.
+    description: ''
+  - isRequired: true
+    name: --target --target-twin-id -t
+    summary: The target twin Id for a relationship.
+    description: ''
+  - name: --properties -p
+    summary: Initial property values for instantiating a digital twin relationship. Provide file path or inline JSON.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_relationship_delete
+  name: az dt twin relationship delete
+  summary: Delete a digital twin relationship on a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Delete a digital twin relationship.
+    syntax:
+      content: az dt twin relationship delete -n {instance_name} --twin-id {twin_id} --relationship-id {relationship_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --relationship-id -r
+    summary: Relationship Id.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_relationship_list
+  name: az dt twin relationship list
+  summary: List the relationships of a digital twin.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: List outgoing relationships of a digital twin.
+    syntax:
+      content: az dt twin relationship list -n {instance_name} --twin-id {twin_id}
+  - summary: List outgoing relationships of a digital twin and filter on relationship 'contains'
+    syntax:
+      content: az dt twin relationship list -n {instance_name} --twin-id {twin_id} --relationship contains
+  - summary: List incoming relationships of a digital twin.
+    syntax:
+      content: az dt twin relationship list -n {instance_name} --twin-id {twin_id} --incoming
+  - summary: List incoming relationships of a digital twin and filter on relationship 'contains'.
+    syntax:
+      content: az dt twin relationship list -n {instance_name} --twin-id {twin_id} --relationship contains --incoming
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --incoming
+    parameterValueGroup: false, true
+    summary: Retrieves all incoming relationships for a digital twin.
+    description: ''
+  - name: --kind --relationship
+    summary: Filter result by the kind of relationship.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_relationship_show
+  name: az dt twin relationship show
+  summary: Show details of a digital twin relationship.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Show details of a digital twin relationship.
+    syntax:
+      content: az dt twin relationship show -n {instance_name} --twin-id {twin_id} --relationship-id {relationship_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --relationship-id -r
+    summary: Relationship Id.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+- uid: ext_azure-iot_az_dt_twin_relationship_update
+  name: az dt twin relationship update
+  summary: Updates the properties of a relationship between two digital twins via JSON patch specification.
+  description: Operations are limited to add, replace and remove.
+  langs:
+  - azurecli
+  examples:
+  - summary: Update a digital twin relationship via JSON patch specification.
+    syntax:
+      content: "az dt twin relationship update -n {instance_name} --twin-id {twin_id} --relationship-id {relationship_id} --relationship contains --json-patch '{\"op\":\"replace\", \"path\":\"/Temperature\", \"value\": 20.5}'"
+  - summary: Update a digital twin relationship via JSON patch specification.
+    syntax:
+      content: >-
+        az dt twin relationship update -n {instance_name} --twin-id {twin_id} --relationship-id {relationship_id} --relationship contains --json-patch '[
+          {"op":"replace", "path":"/Temperature", "value": 20.5},
+          {"op":"add", "path":"/Areas", "value": ["ControlSystem"]}
+        ]'
+  - summary: Update a digital twin relationship via JSON patch specification defined in a file.
+    syntax:
+      content: az dt twin relationship update -n {instance_name} --twin-id {twin_id} --relationship-id {relationship_id} --relationship contains --json-patch ./my/patch/document.json
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --json-patch --patch
+    summary: An update specification described by JSON-patch. Updates to property values and $model elements may happen in the same request. Operations are limited to add, replace and remove. Provide file path or inline JSON.
+    description: ''
+  - isRequired: true
+    name: --relationship-id -r
+    summary: Relationship Id.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_twin_relationship_create
+  name: az dt twin relationship create
+  summary: Create a relationship between source and target digital twins.
+- uid: ext_azure-iot_az_dt_twin_relationship_delete
+  name: az dt twin relationship delete
+  summary: Delete a digital twin relationship on a Digital Twins instance.
+- uid: ext_azure-iot_az_dt_twin_relationship_list
+  name: az dt twin relationship list
+  summary: List the relationships of a digital twin.
+- uid: ext_azure-iot_az_dt_twin_relationship_show
+  name: az dt twin relationship show
+  summary: Show details of a digital twin relationship.
+- uid: ext_azure-iot_az_dt_twin_relationship_update
+  name: az dt twin relationship update
+  summary: Updates the properties of a relationship between two digital twins via JSON patch specification.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Manage and configure the digital twin relationships of a Digital Twins instance.

--- a/latest/docs-ref-autogen/ext/azure-iot/dt/twin/telemetry.yml
+++ b/latest/docs-ref-autogen/ext/azure-iot/dt/twin/telemetry.yml
@@ -1,0 +1,61 @@
+### YamlMime:UniversalReference
+items:
+- uid: ext_azure-iot_az_dt_twin_telemetry
+  name: az dt twin telemetry
+  summary: Test and validate the event routes and endpoints of a Digital Twins instance.
+  description: ''
+  langs:
+  - azurecli
+  children:
+  - ext_azure-iot_az_dt_twin_telemetry_send
+- uid: ext_azure-iot_az_dt_twin_telemetry_send
+  name: az dt twin telemetry send
+  summary: Sends telemetry on behalf of a digital twin. If component path is provided the emitted telemetry is on behalf of the component.
+  description: ''
+  langs:
+  - azurecli
+  examples:
+  - summary: Send twin telemetry
+    syntax:
+      content: az dt twin telemetry send -n {instance_name} --twin-id {twin_id}
+  parameters:
+  - isRequired: true
+    name: --dt-name --dtn -n
+    summary: Digital Twins instance name.
+    description: ''
+  - isRequired: true
+    name: --twin-id -t
+    summary: The digital twin Id.
+    description: ''
+  - name: --component
+    summary: The path to the DTDL component. If set, telemetry will be emitted on behalf of the component.
+    description: ''
+  - name: --dt-id
+    summary: A unique message identifier (in the scope of the digital twin id) that is commonly used for de-duplicating messages. If no value is provided a GUID is automatically generated.
+    description: ''
+  - name: --resource-group -g
+    summary: Digital Twins instance resource group. You can configure the default group using `az configure --defaults group=&lt;name&gt;`.
+    description: ''
+  - name: --telemetry
+    summary: 'Inline telemetry JSON or file path to telemetry JSON. Default payload is an empty object: {}.'
+    description: ''
+commands:
+- uid: ext_azure-iot_az_dt_twin_telemetry_send
+  name: az dt twin telemetry send
+  summary: Sends telemetry on behalf of a digital twin. If component path is provided the emitted telemetry is on behalf of the component.
+globalParameters:
+- name: --debug
+  summary: Increase logging verbosity to show all debug logs.
+- name: --help -h
+  summary: Show this help message and exit.
+- name: --only-show-errors
+  summary: Only show errors, suppressing warnings.
+- name: --output -o
+  defaultValue: json
+  parameterValueGroup: json, jsonc, table, tsv
+  summary: Output format.
+- name: --query
+  summary: JMESPath query string. See <a href="http://jmespath.org/">http://jmespath.org/</a> for more information and examples.
+- name: --verbose
+  summary: Increase logging verbosity. Use --debug for full debug logs.
+description: Test and validate the event routes and endpoints of a Digital Twins instance.

--- a/latest/docs-ref-autogen/ext/azure-iot/index.yml
+++ b/latest/docs-ref-autogen/ext/azure-iot/index.yml
@@ -8,6 +8,9 @@ items:
   - azurecli
   children: []
 commands:
+- uid: ext_azure-iot_az_dt
+  name: az dt
+  summary: Manage Azure Digital Twins (ADT) solutions & infrastructure.
 - uid: ext_azure-iot_az_iot
   name: az iot
   summary: Manage Internet of Things (IoT) assets. Augmented with the IoT extension.


### PR DESCRIPTION
Update azure-iot extension reference documentation with Digital Twin content.

This is for needing updated CLI extension reference content before the Azure CLI release automation process.