### PR TITLE
Tested Ubuntu focal 20.04 is supported

### DIFF
--- a/docs-ref-conceptual/install-azure-cli-apt.md
+++ b/docs-ref-conceptual/install-azure-cli-apt.md
@@ -16,7 +16,7 @@ ms.custom: devx-track-azurecli
 If you are running a distribution that comes with `apt`, such as Ubuntu or Debian, there's an x86_64 package available
 for the Azure CLI. This package has been tested with and is supported for:
 
-* Ubuntu trusty, xenial, artful, bionic, and disco
+* Ubuntu trusty, xenial, artful, bionic, disco and focal
 * Debian wheezy, jessie, stretch, and buster
 
 [!INCLUDE [current-version](includes/current-version.md)]


### PR DESCRIPTION
I have Ubuntu Focal on my machine. I have installed the package **azure-cli** and it is working well on my machine. No error encountered during installation.
Also tried few operations, working flawlessly. 
So added focal as well in doc,