### PR TITLE
Added version requirement for az upgrade

### DIFF
--- a/docs-ref-conceptual/includes/az-upgrade.md
+++ b/docs-ref-conceptual/includes/az-upgrade.md
@@ -13,4 +13,6 @@ az upgrade
 
 > [!NOTE]
 >
+> The `az upgrade` command was added in version 2.11.0 and will not work with versions prior to 2.11.0.
+>
 > This command will also update all installed extensions by default. For more `az upgrade` options, please refer to the [command reference page](/cli/azure/reference-index#az_upgrade).


### PR DESCRIPTION
Added version requirement for az upgrade to clarify that the command does not work with versions prior to 2.11.0.