### PR TITLE
Updating instructions for ARM64.

### DIFF
--- a/docs-ref-conceptual/install-azure-cli-apt.md
+++ b/docs-ref-conceptual/install-azure-cli-apt.md
@@ -66,7 +66,7 @@ If you don't want to run a script as superuser or the all-in-one script fails, f
         sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
     ```
 
-3. <div id="set-release"/>Add the Azure CLI software repository:
+3. <div id="set-release"/>Add the Azure CLI software repository (Skip this step on ARM64 Linux distributions):
 
     ```bash
     AZ_REPO=$(lsb_release -cs)


### PR DESCRIPTION
Step 3 in the installation instructions are hard coded to assume `amd64` (x64).  Omitting the step works fine on `arm64` installs, so adding parenthetic note to skip the step on arm64 devices.