### PR TITLE
Message fixing: Finish 'view=' fixes in this repo, under 'docs-ref-conceptual/'.

### DIFF
--- a/docs-ref-conceptual/includes/azure-cli-prepare-your-environment-h3.md
+++ b/docs-ref-conceptual/includes/azure-cli-prepare-your-environment-h3.md
@@ -18,4 +18,4 @@ ms.custom: devx-track-azurecli
 - If you prefer, [install](../install-azure-cli.md) the Azure CLI to run CLI reference commands.
    - If you're using a local install, sign in with Azure CLI by using the [az login](/cli/azure/reference-index#az_login) command.  To finish the authentication process, follow the steps displayed in your terminal.  See [Sign in with Azure CLI](../authenticate-azure-cli.md) for additional sign-in options.
   - When you're prompted, install Azure CLI extensions on first use.  For more information about extensions, see [Use extensions with Azure CLI](../azure-cli-extensions-overview.md).
-  - Run [az version](/cli/azure/reference-index?#az_version) to find the version and dependent libraries that are installed. To upgrade to the latest version, run [az upgrade](/cli/azure/reference-index?#az_upgrade).
+  - Run [az version](/cli/azure/reference-index#az_version) to find the version and dependent libraries that are installed. To upgrade to the latest version, run [az upgrade](/cli/azure/reference-index#az_upgrade).

--- a/docs-ref-conceptual/includes/azure-cli-prepare-your-environment-no-header.md
+++ b/docs-ref-conceptual/includes/azure-cli-prepare-your-environment-no-header.md
@@ -13,4 +13,4 @@ ms.custom: devx-track-azurecli
 - If you prefer, [install](../install-azure-cli.md) the Azure CLI to run CLI reference commands.
    - If you're using a local install, sign in with Azure CLI by using the [az login](/cli/azure/reference-index#az_login) command.  To finish the authentication process, follow the steps displayed in your terminal.  See [Sign in with Azure CLI](../authenticate-azure-cli.md) for additional sign-in options.
   - When you're prompted, install Azure CLI extensions on first use.  For more information about extensions, see [Use extensions with Azure CLI](../azure-cli-extensions-overview.md).
-  - Run [az version](/cli/azure/reference-index?#az_version) to find the version and dependent libraries that are installed. To upgrade to the latest version, run [az upgrade](/cli/azure/reference-index?#az_upgrade).
+  - Run [az version](/cli/azure/reference-index#az_version) to find the version and dependent libraries that are installed. To upgrade to the latest version, run [az upgrade](/cli/azure/reference-index#az_upgrade).

--- a/docs-ref-conceptual/includes/azure-cli-prepare-your-environment.md
+++ b/docs-ref-conceptual/includes/azure-cli-prepare-your-environment.md
@@ -15,4 +15,4 @@ ms.custom: devx-track-azurecli
 - If you prefer, [install](../install-azure-cli.md) the Azure CLI to run CLI reference commands.
    - If you're using a local install, sign in with Azure CLI by using the [az login](/cli/azure/reference-index#az_login) command.  To finish the authentication process, follow the steps displayed in your terminal.  See [Sign in with Azure CLI](../authenticate-azure-cli.md) for additional sign-in options.
   - When you're prompted, install Azure CLI extensions on first use.  For more information about extensions, see [Use extensions with Azure CLI](../azure-cli-extensions-overview.md).
-  - Run [az version](/cli/azure/reference-index?#az_version) to find the version and dependent libraries that are installed. To upgrade to the latest version, run [az upgrade](/cli/azure/reference-index?#az_upgrade).
+  - Run [az version](/cli/azure/reference-index#az_version) to find the version and dependent libraries that are installed. To upgrade to the latest version, run [az upgrade](/cli/azure/reference-index#az_upgrade).

--- a/docs-ref-conceptual/use-cli-effectively.md
+++ b/docs-ref-conceptual/use-cli-effectively.md
@@ -118,9 +118,9 @@ There may be cases where a service you are interested in does not have CLI comma
 
 If neither generic update arguments nor `az resource` meets your needs, you can use `az rest` command to call the REST API. It automatically authenticates using the logged-in credential and sets header `Content-Type: application/json`.
 
-This is extremely useful for calling [Microsoft Graph API](/graph/api/overview?toc=./ref/toc.json&view=graph-rest-1.0) which is not currently supported by CLI commands ([#12946](https://github.com/Azure/azure-cli/issues/12946)).
+This is extremely useful for calling [Microsoft Graph API](/graph/api/overview?toc=./ref/toc.json) which is not currently supported by CLI commands ([#12946](https://github.com/Azure/azure-cli/issues/12946)).
 
-For example, to update `redirectUris` for an [Application](/graph/api/resources/application?view=graph-rest-1.0), we call the [Update application](/graph/api/application-update?view=graph-rest-1.0&tabs=http) REST API with:
+For example, to update `redirectUris` for an [Application](/graph/api/resources/application), we call the [Update application](/graph/api/application-update?tabs=http) REST API with:
 
 ```sh
 # Line breaks for legibility only


### PR DESCRIPTION
Message fixing: Finish 'view=' fixes in this repo, under 'docs-ref-conceptual/'.

In a separate email, I am asking Celeste de Guzman and Mike Tillman (M1 & M2) their opinion on the proposed removal of the `?view=graph-rest-1.0` URL parameter we see here in this PR, and in PR #2325.

GeneMi (= MightyPen)
