### PR TITLE
displayName is required based on cli command

### DIFF
--- a/latest/docs-ref-autogen/ext/subscription/account.yml
+++ b/latest/docs-ref-autogen/ext/subscription/account.yml
@@ -11,7 +11,7 @@ directCommands:
   syntax: >-
     az account create --enrollment-account-name
                       --offer-type {MS-AZR-0017P, MS-AZR-0148P}
-                      [--display-name]
+                      --display-name
                       [--owner-object-id]
                       [--owner-spn]
                       [--owner-upn]
@@ -25,10 +25,11 @@ directCommands:
     parameterValueGroup: MS-AZR-0017P, MS-AZR-0148P
     summary: The offer type of the subscription. For example, MS-AZR-0017P (EnterpriseAgreement) and MS-AZR-0148P (EnterpriseAgreement devTest) are available.
     description: ''
-  optionalParameters:
-  - name: --display-name
+  - isRequired: true
+    name: --display-name
     summary: The display name of the subscription.
     description: ''
+  optionalParameters:
   - name: --owner-object-id
     summary: The object id(s) of the owner(s) which should be granted access to the new subscription.
     description: ''


### PR DESCRIPTION
Added displayName as a required property and hopefully have it covered in all the places.  This is in reference to issue https://github.com/Azure/azure-cli-extensions/issues/2088 

Here is the command to replicate existing error:
`az account create --enrollment-account-name "enroomentAccountName" --offer-type "MS-AZR-0017P"`
`MissingParameter - Required parameter DisplayName not provided.`