### PR TITLE
Revert **emphasis** back to `inline code`

### DIFF
--- a/docs-ref-conceptual/azure-cli-configuration.md
+++ b/docs-ref-conceptual/azure-cli-configuration.md
@@ -13,20 +13,20 @@ ms.custom: devx-track-azurecli
 # Azure CLI configuration
 
 The Azure CLI allows for user configuration for settings such as logging, data collection, and default argument values.
-The CLI offers a convenience command for managing some defaults, **az configure**. Other values can be set in a
+The CLI offers a convenience command for managing some defaults, `az configure`. Other values can be set in a
 configuration file or with environment variables.
 
 Configuration values used by the CLI are evaluated in the following precedence, with items higher on the list taking priority.
 
 1. Command-line parameters
-1. Parameter persisted values set with **az config param-persist**
+1. Parameter persisted values set with `az config param-persist`
 1. Environment variables
-1. Values in the configuration file set with **az configure**
+1. Values in the configuration file set with `az configure`
 
 ## CLI configuration with az configure
 
 You set defaults for the CLI with the [az configure](/cli/azure/reference-index#az-configure) command.
-This command takes one argument, **--defaults**, which is a space-separated list of `key=value` pairs. The provided values are used by the CLI in place of
+This command takes one argument, `--defaults`, which is a space-separated list of `key=value` pairs. The provided values are used by the CLI in place of
 required arguments.
 
 The following table contains a list of available configuration keys.
@@ -35,21 +35,21 @@ The following table contains a list of available configuration keys.
 |------|-------------|
 | group | The default resource group to use for all commands. |
 | location | The default location to use for all commands. |
-| web | The default app name to use for **az webapp** commands. |
-| vm | The default VM name to use for **az vm** commands. |
-| vmss | The default virtual machine scale set (VMSS) name to use for  **az vmss** commands. |
-| acr | The default container registry name to use for **az acr** commands. |
+| web | The default app name to use for `az webapp` commands. |
+| vm | The default VM name to use for `az vm` commands. |
+| vmss | The default virtual machine scale set (VMSS) name to use for  `az vmss` commands. |
+| acr | The default container registry name to use for `az acr` commands. |
 
 As an example, here's how you would set the default resource group and location for all commands.
 
-`azurecli-interactive
+```azurecli-interactive
 az configure --defaults location=westus2 group=MyResourceGroup
-`
+```
 
 ## CLI configuration file
 
 The CLI configuration file contains other settings that are used for managing CLI behavior. The configuration file itself is located
-at _$AZURE_CONFIG_DIR/config_. The default value of **AZURE_CONFIG_DIR** is `$HOME/.azure` on Linux and macOS,
+at `$AZURE_CONFIG_DIR/config`. The default value of `AZURE_CONFIG_DIR` is `$HOME/.azure` on Linux and macOS,
 and `%USERPROFILE%\.azure` on Windows.
 
 Configuration files are written in the INI file format. This file format is defined by section headers, followed by a list of key-value entries.
@@ -60,19 +60,19 @@ Configuration files are written in the INI file format. This file format is defi
 
 Booleans are case-insensitive, and are represented by the following values.
 
-* __True__: 1, yes, true, on
-* __False__: 0, no, false, off
+* __True__: `1`, `yes`, `true`, `on`
+* __False__: `0`, `no`, `false`, `off`
 
 Here's an example of a CLI configuration file that disables any confirmation prompts and sets up logging to the `/var/log/azure` directory.
 
-`ini
+```ini
 [core]
 disable_confirm_prompt=Yes
 
 [logging]
 enable_log_file=yes
 log_dir=/var/log/azure
-`
+```
 
 See the next section for details on all of the available configuration values and what they mean. For the full details on the INI file format,
 see the [Python documentation on INI](https://docs.python.org/3/library/configparser.html#supported-ini-file-structure).
@@ -80,42 +80,42 @@ see the [Python documentation on INI](https://docs.python.org/3/library/configpa
 ## CLI configuration values and environment variables
 
 The following table contains all of the sections and option names that can be placed in a configuration file. Their corresponding
-environment variables are set as **AZURE_{section}_{name}**, in all caps. For example, `output` default for `core` is set in the **AZURE_CORE_OUTPUT** variable, the `storage_account` default for `batchai` is set in the **AZURE_BATCHAI_STORAGE_ACCOUNT** variable, and the default `location` is set in the **AZURE_DEFAULTS_LOCATION** variable.
+environment variables are set as `AZURE_{section}_{name}`, in all caps. For example, `output` default for `core` is set in the `AZURE_CORE_OUTPUT` variable, the `storage_account` default for `batchai` is set in the `AZURE_BATCHAI_STORAGE_ACCOUNT` variable, and the default `location` is set in the `AZURE_DEFAULTS_LOCATION` variable.
 
 When you provide a default value, that argument is no longer required by any command. Instead, the default value is used.
 
 | Section | Name      | Type | Description|
 |---------|-----------|------|------------|
-| __core__ | output | string | The default output format. Can be one of **json**, **jsonc**, **tsv**, or **table**. |
+| __core__ | output | string | The default output format. Can be one of `json`, `jsonc`, `tsv`, or `table`. |
 | | disable\_confirm\_prompt | boolean | Turn confirmation prompts on/off. |
 | | collect\_telemetry | boolean | Allow Microsoft to collect anonymous data on the usage of the CLI. For privacy information, see the [Azure CLI MIT license](https://github.com/Azure/azure-cli/blob/dev/LICENSE). |
-| | only\_show\_errors | boolean | Only show errors during command invocation. In other words, only errors will be written to **stderr**. It suppresses warnings from preview, deprecated and experimental commands. It is also available for individual commands with the **--only-show-errors** parameter. |
-| | no\_color | boolean | Disable color. Originally colored messages will be prefixed with `DEBUG`, `INFO`, `WARNING` and `ERROR`. This bypasses the issue of a third-party library where the terminal's color cannot revert back after a **stdout** redirection. |
+| | only\_show\_errors | boolean | Only show errors during command invocation. In other words, only errors will be written to `stderr`. It suppresses warnings from preview, deprecated and experimental commands. It is also available for individual commands with the `--only-show-errors` parameter. |
+| | no\_color | boolean | Disable color. Originally colored messages will be prefixed with `DEBUG`, `INFO`, `WARNING` and `ERROR`. This bypasses the issue of a third-party library where the terminal's color cannot revert back after a `stdout` redirection. |
 | __logging__ | enable\_log\_file | boolean | Turn logging on/off. |
 | | log\_dir | string | The directory to write logs to. By default this value is `${AZURE_CONFIG_DIR}/logs*`. |
 | __defaults__ | group | string | The default resource group to use for all commands. |
 | | location | string | The default location to use for all commands. |
-| | web | string | The default app name to use for **az webapp** commands. |
-| | vm | string | The default VM name to use for **az vm** commands. |
-| | vmss | string | The default virtual machine scale set (VMSS) name to use for **az vmss** commands. |
-| | acr | string | The default container registry name to use for **az acr** commands. |
-| __storage__ | connection\_string | string | The default connection string to use for **az storage** commands. |
-| | account | string | The default account name to use for **az storage** commands. |
-| | key | string | The default account key to use for **az storage** commands. |
-| | sas\_token | string | The default SAS token to use for **az storage** commands. |
-| __batchai__ | storage\_account | string | The default storage account to use for **az batchai** commands. |
-| | storage\_key | string | The default storage key to use for **az batchai** commands. |
-| __batch__ | account | string | The default Azure Batch account name to use for **az batch** commands. |
-| | access\_key | string | The default access key to use for **az batch** commands. Only used with `aad` authorization. |
-| | endpoint | string | The default endpoint to connect to for **az batch** commands. |
-| | auth\_mode | string | The authorization mode to use for **az batch** commands. Can be `shared_key` or `aad`. |
-| __cloud__ | name | string | The default cloud for all **az** commands.  The possible values are  `AzureCloud` (default), `AzureChinaCloud`, `AzureUSGovernment`, `AzureGermanCloud`. To change clouds, you can use the **az cloud set –name** command.  For an example, see [Manage Clouds with the Azure CLI](manage-clouds-azure-cli.md). |
+| | web | string | The default app name to use for `az webapp` commands. |
+| | vm | string | The default VM name to use for `az vm` commands. |
+| | vmss | string | The default virtual machine scale set (VMSS) name to use for `az vmss` commands. |
+| | acr | string | The default container registry name to use for `az acr` commands. |
+| __storage__ | connection\_string | string | The default connection string to use for `az storage` commands. |
+| | account | string | The default account name to use for `az storage` commands. |
+| | key | string | The default account key to use for `az storage` commands. |
+| | sas\_token | string | The default SAS token to use for `az storage` commands. |
+| __batchai__ | storage\_account | string | The default storage account to use for `az batchai` commands. |
+| | storage\_key | string | The default storage key to use for `az batchai` commands. |
+| __batch__ | account | string | The default Azure Batch account name to use for `az batch` commands. |
+| | access\_key | string | The default access key to use for `az batch` commands. Only used with `aad` authorization. |
+| | endpoint | string | The default endpoint to connect to for `az batch` commands. |
+| | auth\_mode | string | The authorization mode to use for `az batch` commands. Can be `shared_key` or `aad`. |
+| __cloud__ | name | string | The default cloud for all `az` commands.  The possible values are  `AzureCloud` (default), `AzureChinaCloud`, `AzureUSGovernment`, `AzureGermanCloud`. To change clouds, you can use the `az cloud set –name` command.  For an example, see [Manage Clouds with the Azure CLI](manage-clouds-azure-cli.md). |
 | __extension__ | use_dynamic_install | string | Install an extension if it's not added yet when running a command from it. The possible values are `no` (default), `yes_prompt`, `yes_without_prompt`. |
 | | run_after_dynamic_install | boolean | Continue to run the command when an extension is dynamically installed for it. Default is `False`. |
 
 > [!NOTE]
 > You may see other values in your configuration file, but these are managed directly through CLI commands,
-> including **az configure**. The ones listed in the table above are the only values you should change yourself.
+> including `az configure`. The ones listed in the table above are the only values you should change yourself.
 
 ## See also
 

--- a/docs-ref-conceptual/param-persist-howto.md
+++ b/docs-ref-conceptual/param-persist-howto.md
@@ -19,19 +19,19 @@ The Azure CLI [az config param-persist](/cli/azure/param-persist) reference prov
 Configuration values used by the CLI are evaluated in the following precedence, with items higher on the list taking priority.
 
 1. Command-line parameters
-1. Values in the local working directory set by **az config param-persist**
+1. Values in the local working directory set by `az config param-persist`
 1. Environment variables
-1. Values in the configuration file or set with **az config**
+1. Values in the configuration file or set with `az config`
 
-[Install the Azure CLI](install-azure-cli.md) or open [Azure Cloud Shell](https://shell.azure.com) to run the scripts in this article.  If you are using a local install of the Azure CLI, version 2.12.0 or later is needed to run **az config param-persist** commands.  Run [az version](/cli/azure/reference-index#az_version) to find the version and dependent libraries that are installed. To upgrade to the latest version, run [az upgrade](/cli/azure/reference-index#az_upgrade).  Azure Cloud Shell always has the latest version of the Azure CLI.
+[Install the Azure CLI](install-azure-cli.md) or open [Azure Cloud Shell](https://shell.azure.com) to run the scripts in this article.  If you are using a local install of the Azure CLI, version 2.12.0 or later is needed to run `az config param-persist` commands.  Run [az version](/cli/azure/reference-index#az_version) to find the version and dependent libraries that are installed. To upgrade to the latest version, run [az upgrade](/cli/azure/reference-index#az_upgrade).  Azure Cloud Shell always has the latest version of the Azure CLI.
 
 ## Persisted parameter data file
 
-Persisted parameter values are kept in a file named **.param_persist** which is stored in your working directory.  If you are using [Azure Cloud Shell](https://shell.azure.com) to execute Azure CLI commands, your working directory is in the storage account being used by the Azure CLI.  If you are using a [local install](/install-azure-cli) of the Azure CLI, your working directory is on your local machine.  In either location, the **.param_persist** file is hidden and should not be manually updated.
+Persisted parameter values are kept in a file named `.param_persist` which is stored in your working directory.  If you are using [Azure Cloud Shell](https://shell.azure.com) to execute Azure CLI commands, your working directory is in the storage account being used by the Azure CLI.  If you are using a [local install](/install-azure-cli) of the Azure CLI, your working directory is on your local machine.  In either location, the `.param_persist` file is hidden and should not be manually updated.
 
 ## Persisted parameter storage and support
 
-The following Azure CLI parameters are supported by persisted parameter.  The **resource_group_name** and **location** parameters are stored differently in that you can add them to persisted parameter _without_ executing a create command.
+The following Azure CLI parameters are supported by persisted parameter.  The `resource_group_name` and `location` parameters are stored differently in that you can add them to persisted parameter _without_ executing a create command.
 
 | Persisted parameter | Storage action | Supported by
 |-|-|-|
@@ -44,7 +44,7 @@ The following Azure CLI parameters are supported by persisted parameter.  The **
 
 ## Sample script using persisted parameters
 
-Without persisted parameters, sequential CLI commands must repeat the same parameter values.  With persisted parameters enabled, your stored parameter values can be omitted from sequential commands.  In this example, the **location**, **resource group name** or **storage account name** are repeated in subsequent commands.
+Without persisted parameters, sequential CLI commands must repeat the same parameter values.  With persisted parameters enabled, your stored parameter values can be omitted from sequential commands.  In this example, the `location`, `resource group name` or `storage account name` are repeated in subsequent commands.
 
 ```azurecli
 # Reminder: function app and storage account names must be unique.
@@ -72,7 +72,7 @@ az config param-persist show
 
 ## Persisted parameter and global variable comparison
 
-There are two Azure CLI commands that can be used to default parameter values: **az configure** and **az config param-persist**.  Use the **az configure** command to specify _global variables_ such as group, location, or web.  Use **az param-persist** to specify _local default values_ unique to your workload.  Stored values are used by the CLI in place of required arguments.
+There are two Azure CLI commands that can be used to default parameter values: `az configure` and `az config param-persist`.  Use the `az configure` command to specify _global variables_ such as group, location, or web.  Use `az param-persist` to specify _local default values_ unique to your workload.  Stored values are used by the CLI in place of required arguments.
 
 > [!Important]
 > Persisted parameters override global context values.
@@ -80,12 +80,12 @@ There are two Azure CLI commands that can be used to default parameter values: *
 
 | Reference | Scope | Set | Use
 |-|-|-|-|
-[az configure](/cli/azure/reference-index#az_configure) | Scoped globally across the CLI | Set explicitly using **az configure --defaults** | Use for settings such as logging, data collection, and default argument values
+[az configure](/cli/azure/reference-index#az_configure) | Scoped globally across the CLI | Set explicitly using `az configure --defaults` | Use for settings such as logging, data collection, and default argument values
 [az config param-persist](/cli/azure/config/param-persist) | Scoped locally to a specific working directory | Set automatically once persisted parameters are turned on | Use for individual workload sequential commands.
 
 ### Command examples
 
-Use **az config param-persist** to set a global variable used in the creation of an Azure storage account.
+Use `az config param-persist` to set a global variable used in the creation of an Azure storage account.
 
 ```azurecli
 # set the global variable for resource group
@@ -118,7 +118,7 @@ CLI command output shows that a new storage account was created in the resource 
 ...
 ```
 
-Use **az config param-persist** to set persisted parameters used in the creation of an Azure storage account.  If a global variable is set for the same object, the persisted parameter will override the global variable.
+Use `az config param-persist` to set persisted parameters used in the creation of an Azure storage account.  If a global variable is set for the same object, the persisted parameter will override the global variable.
 
 ```azurecli
 # turn persisted parameter on
@@ -158,4 +158,3 @@ Even with a global variable set for resource group with a value of `myGlobalVari
 
 * [Tutorial: Use persisted parameter with sequential Azure CLI commands](param-persist-tutorial.md)
 * [Azure CLI Configuration using az configure](azure-cli-configuration.md)
-

--- a/docs-ref-conceptual/param-persist-tutorial.md
+++ b/docs-ref-conceptual/param-persist-tutorial.md
@@ -19,7 +19,7 @@ Azure CLI offers persisted parameters that enable you to store parameter values 
 In this tutorial, you will learn to:
 
 > [!div class="checklist"]
-> * Use **az config param-persist** reference commands
+> * Use `az config param-persist` reference commands
 > * Execute sequential commands using persisted parameters
 
 This tutorial uses the following Azure CLI commands
@@ -72,7 +72,7 @@ cd azCLI
 
 ## 2. Turn on Persisted parameters
 
-[Persisted parameters](/cli/azure/param-persist) must be turned on before parameter values can be stored.  You will receive a warning until **az config param-persist** moves out of the experimental stage.  See [Overview: Azure CLI reference types and status](/cli/azure/reference-types-and-status) to learn about the Azure CLI reference types, status, and support levels.
+[Persisted parameters](/cli/azure/param-persist) must be turned on before parameter values can be stored.  You will receive a warning until `az config param-persist` moves out of the experimental stage.  See [Overview: Azure CLI reference types and status](/cli/azure/reference-types-and-status) to learn about the Azure CLI reference types, status, and support levels.
 
 ```azurecli
 az config param-persist on
@@ -80,7 +80,7 @@ az config param-persist on
 
 ## 3. Create persisted parameters
 
-To store values for persisted parameters, execute an Azure CLI command of your choice that contains the parameters you want to store.  For example, create a resource group and the **--location** and **--name** parameters are stored for future use.
+To store values for persisted parameters, execute an Azure CLI command of your choice that contains the parameters you want to store.  For example, create a resource group and the `--location` and `--name` parameters are stored for future use.
 
 1. Store the location and resource group name.
    ```azurecli
@@ -122,13 +122,13 @@ To store values for persisted parameters, execute an Azure CLI command of your c
 
 1. Create a persisted parameter without creating a new resource.
 
-   If you do not want to create a new Azure resource, **resource_group_name** and **location** parameters can be stored by using non-create commands like **show** or **list**.   See [Azure CLI persisted parameters](/cli/azure/param-persist-howto#compare-parameter-persistence-and-global-variables) for a full list of supported parameters,   and the action needed to retain values.  This example also removes all parameter values by using the [az config param-persist delete](/cli/azure/config/param-persist#az-param-persist-delete) command.
+   If you do not want to create a new Azure resource, `resource_group_name` and `location` parameters can be stored by using non-create commands like `show` or `list`.   See [Azure CLI persisted parameters](/cli/azure/param-persist-howto#compare-parameter-persistence-and-global-variables) for a full list of supported parameters,   and the action needed to retain values.  This example also removes all parameter values by using the [az config param-persist delete](/cli/azure/config/param-persist#az-param-persist-delete) command.
 
    ```azurecli
    # Clear all persisted parameters for demonstration.
    az config param-persist delete --all
 
-   # List all storage accounts which will create the **resource_group_name** stored parameter value.
+   # List all storage accounts which will create the `resource_group_name` stored parameter value.
    az storage account show --resource-group RG1forTutorial --name sa1fortutorial
 
    # See the new stored value created for resource group.  The storage account name is only stored with a 'create' command.


### PR DESCRIPTION
Revert **emphasis** back to `inline code` (changed by bba38e9b8d57d71c463c6efff0966c851964e41a), per [Markdown convention](https://guides.github.com/features/mastering-markdown/). 

Affected docs: 

- https://docs.microsoft.com/en-us/cli/azure/azure-cli-configuration
- https://docs.microsoft.com/en-us/cli/azure/param-persist-howto
- https://docs.microsoft.com/en-us/cli/azure/param-persist-tutorial