### PR TITLE
Add example for config option storage.account

### DIFF
--- a/docs-ref-conceptual/azure-cli-configuration.md
+++ b/docs-ref-conceptual/azure-cli-configuration.md
@@ -97,10 +97,10 @@ When you provide a default value, that argument is no longer required by any com
 | | vm | string | The default VM name to use for `az vm` commands. |
 | | vmss | string | The default virtual machine scale set (VMSS) name to use for `az vmss` commands. |
 | | acr | string | The default container registry name to use for `az acr` commands. |
-| __storage__ | connection\_string | string | The default connection string to use for `az storage` commands. |
-| | account | string | The default account name to use for `az storage` commands. |
-| | key | string | The default account key to use for `az storage` commands. |
+| __storage__ | account | string | The default storage account name (e.g., **mystorageaccount** in https://mystorageaccount.blob.core.windows.net) to use for `az storage` data-plane commands (e.g., `az storage container list`). |
+| | key | string | The default access key to use for `az storage` commands. |
 | | sas\_token | string | The default SAS token to use for `az storage` commands. |
+| | connection\_string | string | The default connection string to use for `az storage` commands. |
 | __batchai__ | storage\_account | string | The default storage account to use for `az batchai` commands. |
 | | storage\_key | string | The default storage key to use for `az batchai` commands. |
 | __batch__ | account | string | The default Azure Batch account name to use for `az batch` commands. |

--- a/docs-ref-conceptual/azure-cli-configuration.md
+++ b/docs-ref-conceptual/azure-cli-configuration.md
@@ -98,9 +98,9 @@ When you provide a default value, that argument is no longer required by any com
 | | vmss | string | The default virtual machine scale set (VMSS) name to use for `az vmss` commands. |
 | | acr | string | The default container registry name to use for `az acr` commands. |
 | __storage__ | account | string | The default storage account name (e.g., **mystorageaccount** in https://mystorageaccount.blob.core.windows.net) to use for `az storage` data-plane commands (e.g., `az storage container list`). |
-| | key | string | The default access key to use for `az storage` commands. |
-| | sas\_token | string | The default SAS token to use for `az storage` commands. |
-| | connection\_string | string | The default connection string to use for `az storage` commands. |
+| | key | string | The default access key to use for `az storage` data-plane commands. |
+| | sas\_token | string | The default SAS token to use for `az storage` data-plane commands. |
+| | connection\_string | string | The default connection string to use for `az storage` data-plane commands. |
 | __batchai__ | storage\_account | string | The default storage account to use for `az batchai` commands. |
 | | storage\_key | string | The default storage key to use for `az batchai` commands. |
 | __batch__ | account | string | The default Azure Batch account name to use for `az batch` commands. |


### PR DESCRIPTION
A user can mistake **storage.account** for the **account** from `az account`.

The user may run

```
az config set storage.account=<subscription ID>
```

and expect `az storage` commands to operate under this subscription, which will not work as expected of course. 

The correct way to select a subscription to use 

```
az account set --subscription <subscription ID>
```

**storage.account** is actually designed for storage account name, like **mystorageaccount** in https://mystorageaccount.blob.core.windows.net.

Email: _Looking for clarity on default subscription information_