### PR TITLE
Add credential and role assignment warning for creating service principal

### DIFF
--- a/docs-ref-conceptual/create-an-azure-service-principal-azure-cli.md
+++ b/docs-ref-conceptual/create-an-azure-service-principal-azure-cli.md
@@ -29,12 +29,19 @@ This article shows you the steps for creating, getting information about, and re
 
 Create a service principal with the [az ad sp create-for-rbac](/cli/azure/ad/sp#az-ad-sp-create-for-rbac) command. When creating a service principal, you choose the type of sign-in authentication it uses.
 
+There are two types of authentication available for service principals: Password-based authentication, and certificate-based authentication.
+
 > [!NOTE]
 >
 > If your account doesn't have permission to create a service principal, `az ad sp create-for-rbac` will return an error message containing
 > "Insufficient privileges to complete the operation." Contact your Azure Active Directory admin to create a service principal.
 
-There are two types of authentication available for service principals: Password-based authentication, and certificate-based authentication.
+> [!WARNING]
+> When you create a service principal using the `az ad sp create-for-rbac` command, the output includes credentials that you must protect. Be sure that you do not include these credentials in your code or check the credentials into your source control. As an alternative, consider using [managed identities](/azure/active-directory/managed-identities-azure-resources/overview) if available to avoid the need to use credentials.
+>
+> By default, `az ad sp create-for-rbac` assigns the [Contributor](/azure/role-based-access-control/built-in-roles#contributor) role to the service principal at the subscription scope. To reduce your risk of a compromised service principal, assign a more specific role and narrow the scope to a resource or resource group. See [Steps to add a role assignment](/azure/role-based-access-control/role-assignments-steps) for more information.
+>
+> In a future release, `az ad sp create-for-rbac` will NOT create a 'Contributor' role assignment by default. If needed, use the `--role` argument to explicitly create a role assignment.
 
 ### Password-based authentication
 

--- a/docs-ref-conceptual/create-an-azure-service-principal-azure-cli.md
+++ b/docs-ref-conceptual/create-an-azure-service-principal-azure-cli.md
@@ -41,7 +41,7 @@ There are two types of authentication available for service principals: Password
 >
 > By default, `az ad sp create-for-rbac` assigns the [Contributor](/azure/role-based-access-control/built-in-roles#contributor) role to the service principal at the subscription scope. To reduce your risk of a compromised service principal, assign a more specific role and narrow the scope to a resource or resource group. See [Steps to add a role assignment](/azure/role-based-access-control/role-assignments-steps) for more information.
 >
-> In a future release, `az ad sp create-for-rbac` will NOT create a 'Contributor' role assignment by default. If needed, use the `--role` argument to explicitly create a role assignment.
+> In a future release, `az ad sp create-for-rbac` will NOT create a **Contributor** role assignment by default. If needed, use the `--role` argument to explicitly create a role assignment.
 
 ### Password-based authentication
 


### PR DESCRIPTION
## Context

The **credential** and **role assignment** warning currently only exists in the command help of [`az ad sp create-for-rbac`](https://docs.microsoft.com/en-us/cli/azure/ad/sp?view=azure-cli-latest#az_ad_sp_create_for_rbac), but not in [Create an Azure service principal with the Azure CLI](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli).

Azure PowerShell has this warning in both docs:

- Cmdlet help [`New-AzADServicePrincipal`](https://docs.microsoft.com/en-us/powershell/module/Az.Resources/New-AzADServicePrincipal?view=azps-5.3.0#description) (Added by https://github.com/Azure/azure-powershell/pull/13408)
- Tutorial [Create an Azure service principal with Azure PowerShell](https://docs.microsoft.com/en-us/powershell/azure/create-azure-service-principal-azureps?view=azps-5.3.0) (Added by https://github.com/MicrosoftDocs/azure-docs-powershell/pull/1620)

## Changes

- Add the same **credential** and **role assignment** warning to [Create an Azure service principal with the Azure CLI](https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli).
- Declare the deprecation of the default **Contributor** role assignment