### PR TITLE
Update the url for msi

### DIFF
--- a/docs-ref-conceptual/install-azure-cli-windows.md
+++ b/docs-ref-conceptual/install-azure-cli-windows.md
@@ -99,7 +99,7 @@ or for situations where your machine may be configuration-managed or require adv
 In order to get the MSI, your proxy needs to allow HTTPS connections to the following addresses:
 
 * `https://aka.ms/`
-* `https://azurecliprod.blob.core.windows.net/`
+* `https://azcliprod.blob.core.windows.net/`
 
 ## Uninstall
 


### PR DESCRIPTION
msi is moved to a storage account in AME asubscription. Update the link accordingly in doc.