### PR TITLE
added link to DNS zone configuration page

### DIFF
--- a/latest/docs-ref-autogen/network/private-endpoint.yml
+++ b/latest/docs-ref-autogen/network/private-endpoint.yml
@@ -48,7 +48,7 @@ directCommands:
     description: ''
   optionalParameters:
   - name: --group-id
-    summary: The ID of the group obtained from the remote resource that this private endpoint should connect to. You can use "az network private-link-resource list" to obtain the supported group ids. You must provide this except for PrivateLinkService.
+    summary: The ID of the group obtained from the remote resource that this private endpoint should connect to. To view the list of supported group ids, you can use "az network private-link-resource list" or view the [Azure services DNS zone configuration](https://docs.microsoft.com/en-us/azure/private-link/private-endpoint-dns#azure-services-dns-zone-configuration). You must provide this parameter except for PrivateLinkService.
     description: ''
   - name: --group-ids
     summary: The ID of the group obtained from the remote resource that this private endpoint should connect to. You can use "az network private-link-resource list" to obtain the supported group ids. You must provide this except for PrivateLinkService.


### PR DESCRIPTION
I found it too difficult to get the list of supported group ids, so I added a link to the DNS zone configuration page