### PR TITLE
Az login --service-principal need to use appId

### DIFF
--- a/latest/docs-ref-autogen/reference-index.yml
+++ b/latest/docs-ref-autogen/reference-index.yml
@@ -88,9 +88,9 @@ directCommands:
   - summary: Log in with user name and password. This doesn't work with Microsoft accounts or accounts that have two-factor authentication enabled. Use -p=secret if the first character of the password is '-'.
     syntax: az login -u johndoe@contoso.com -p VerySecret
   - summary: Log in with a service principal using client secret. Use -p=secret if the first character of the password is '-'.
-    syntax: az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p VerySecret --tenant contoso.onmicrosoft.com
+    syntax: az login --service-principal -u 8fac6dfe-8611-4344-b972-446fcc3eb132 -p VerySecret --tenant contoso.onmicrosoft.com
   - summary: Log in with a service principal using client certificate.
-    syntax: az login --service-principal -u http://azure-cli-2016-08-05-14-31-15 -p ~/mycertfile.pem --tenant contoso.onmicrosoft.com
+    syntax: az login --service-principal -u 8fac6dfe-8611-4344-b972-446fcc3eb132 -p ~/mycertfile.pem --tenant contoso.onmicrosoft.com
   - summary: Log in using a VM's system assigned identity
     syntax: az login --identity
   - summary: Log in using a VM's user assigned identity. Client or object ids of the service identity also work
@@ -118,7 +118,7 @@ directCommands:
     summary: Use CLI's old authentication flow based on device code. CLI will also use this if it can't launch a browser in your behalf, e.g. in remote SSH or Cloud Shell.
     description: ''
   - name: --username -u
-    summary: User name, service principal, or managed service identity ID.
+    summary: User principal name (`upn`); service principal or managed service Application identity ID (`appId`, not `objectId`).
     description: ''
   editLink: https://github.com/Azure/azure-cli/blob/dev/src/azure-cli/azure/cli/command_modules/profile/_help.py
 - uid: az_logout


### PR DESCRIPTION
With `az login --service-principal` one must use `-u appId`, but the documentation doesn't say and people often use `objectId`

Also, the current example `-u http://azure-cli-2016-08-05-14-31-15` is quite misleading. Personally, I haven't seen that yet. I propose random `guid` as it looks more like the expected `appId` and ensures uniqueness.