### PR TITLE
Fix ref toc issue when no moniker is specified.

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -79,27 +79,19 @@
   ],
   "JoinTOCPlugin": [
     {
-      "ReferenceTOC": "latest/docs-ref-autogen/toc.yml",
       "ConceptualTOC": "docs-ref-conceptual/toc.yml",
-      "ReferenceTOCUrl": "/cli/azure/command/toc.json?view=azure-cli-latest",
-      "ConceptualTOCUrl": "/cli/azure/toc.json?view=azure-cli-latest"
+      "ReferenceTOCUrl": "/cli/azure/command/toc.json",
+    },
+    {
+      "ReferenceTOC": "latest/docs-ref-autogen/toc.yml",
+      "ConceptualTOCUrl": "/cli/azure/toc.json"
     },
     {
       "ReferenceTOC": "2017-03-09-profile/docs-ref-autogen/toc.yml",
-      "ConceptualTOC": "docs-ref-conceptual/toc.yml",
-      "ReferenceTOCUrl": "/cli/azure/command/toc.json?view=azure-cli-2017-03-09-profile",
-      "ConceptualTOCUrl": "/cli/azure/toc.json?view=azure-cli-2017-03-09-profile"
+      "ConceptualTOCUrl": "/cli/azure/toc.json"
     },
     {
       "ReferenceTOC": "2018-03-01-hybrid/docs-ref-autogen/toc.yml",
-      "ConceptualTOC": "docs-ref-conceptual/toc.yml",
-      "ReferenceTOCUrl": "/cli/azure/command/toc.json?view=azure-cli-2018-03-01-hybrid",
-      "ConceptualTOCUrl": "/cli/azure/toc.json?view=azure-cli-2018-03-01-hybrid"
-    },    
-    {
-      "ReferenceTOC": "docs-ref-autogen/toc.yml",
-      "ConceptualTOC": "docs-ref-conceptual/toc.yml",
-      "ReferenceTOCUrl": "/cli/azure/command/toc.json",
       "ConceptualTOCUrl": "/cli/azure/toc.json"
     }
   ],

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -95,6 +95,12 @@
       "ConceptualTOC": "docs-ref-conceptual/toc.yml",
       "ReferenceTOCUrl": "/cli/azure/command/toc.json?view=azure-cli-2018-03-01-hybrid",
       "ConceptualTOCUrl": "/cli/azure/toc.json?view=azure-cli-2018-03-01-hybrid"
+    },    
+    {
+      "ReferenceTOC": "docs-ref-autogen/toc.yml",
+      "ConceptualTOC": "docs-ref-conceptual/toc.yml",
+      "ReferenceTOCUrl": "/cli/azure/command/toc.json",
+      "ConceptualTOCUrl": "/cli/azure/toc.json"
     }
   ],
   "docs_build_engine": {

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -80,7 +80,7 @@
   "JoinTOCPlugin": [
     {
       "ConceptualTOC": "docs-ref-conceptual/toc.yml",
-      "ReferenceTOCUrl": "/cli/azure/command/toc.json",
+      "ReferenceTOCUrl": "/cli/azure/command/toc.json"
     },
     {
       "ReferenceTOC": "latest/docs-ref-autogen/toc.yml",


### PR DESCRIPTION
Issue: when user access https://docs.microsoft.com/en-us/cli/azure/ with not moniker. The incorrect configuration will let the page use "azure-cli-2018-03-01-hybrid" version of toc.