### PR TITLE
Correct typo in menu link (left) "Manage reference groups" -> "Manage resource groups".

### DIFF
--- a/docs-ref-conceptual/TOC.yml
+++ b/docs-ref-conceptual/TOC.yml
@@ -126,7 +126,7 @@
   - name: Manage subscriptions
     href: manage-azure-subscriptions-azure-cli.md
     displayName: tenant, user, sign in, signin, log in, login, authenticate, authentication, accounts
-  - name: Manage reference groups
+  - name: Manage resource groups
     href: manage-azure-groups-azure-cli.md
   - name: Work in Interactive mode
     href: interactive-azure-cli.md


### PR DESCRIPTION
Link on the left side says "Manage reference groups" but page has then the title "Working with resource groups in Azure CLI". 
So I assume that the link on the left side should actually be "Manage resource groups".