### PR TITLE
Fixes typo in az postgres server create doc example

### DIFF
--- a/latest/docs-ref-autogen/postgres/server.yml
+++ b/latest/docs-ref-autogen/postgres/server.yml
@@ -37,7 +37,7 @@ directCommands:
       az postgres server create -l northeurope -g testgroup -n testsvr -u username -p password \
           --sku-name B_Gen5_1 --ssl-enforcement Enabled --minimal-tls-version TLS1_0 --public-network-access Disabled \
           --backup-retention 10 --geo-redundant-backup Enabled --storage-size 51200 \
-          --tags "key=value" --version 11.0
+          --tags "key=value" --version 11
   optionalParameters:
   - name: --admin-password -p
     summary: 'The password of the administrator. Minimum 8 characters and maximum 128 characters. Password must contain characters from three of the following categories: English uppercase letters, English lowercase letters, numbers, and non-alphanumeric characters.'


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-cli/issues/17032

The feedback button on the bottom of the doc site pointed me to the `azure-cli` repo, so I opened the issue there. Hope that's okay. 