### PR TITLE
Minor update for clarity

### DIFF
--- a/docs-ref-conceptual/install-azure-cli.md
+++ b/docs-ref-conceptual/install-azure-cli.md
@@ -21,7 +21,7 @@ The Azure CLI is available to install in Windows, macOS and Linux environments. 
 
 * [Install on Windows](install-azure-cli-windows.md)
 * [Install on macOS](install-azure-cli-macos.md)
-* Install on Linux or [Windows Subsystem for Linux (WSL)](/windows/wsl/about)
+* Install on Linux or Windows Subsystem for Linux (WSL) ([What is WSL?](/windows/wsl/about))
   * [Install with apt on Debian or Ubuntu](install-azure-cli-apt.md)
   * [Install with dnf on RHEL, Fedora, or CentOS](install-azure-cli-yum.md)
   * [Install with zypper on openSUSE or SLE](install-azure-cli-zypper.md)


### PR DESCRIPTION
Currently it seems like selecting "Install on Linux or Windows Subsystem for Linux (WSL)" should take me to WSL-specific instructions for installation, but instead takes me to the About WSL doc. This minor fixes moves the link into a separate (What is WSL?) link that improves clarity that you can both: 1) Discover what WSL is or 2) Install on Linux with WSL just like you would on Linux (there's no difference in install once WSL is enabled).