### PR TITLE
Update sign in with a managed identity

### DIFF
--- a/docs-ref-conceptual/authenticate-azure-cli.md
+++ b/docs-ref-conceptual/authenticate-azure-cli.md
@@ -114,4 +114,9 @@ On resources configured for managed identities for Azure resources, you can sign
 az login --identity
 ```
 
+If the resource has multiple user assigned managed identities and no system assigned identity, you must specify the client id or object id or resource id of the user assigned managed identity with `--username` for login.
+```azurecli-interactive
+az login --identity --username <client_id|object_id|resource_id>
+```
+
 To learn more about managed identities for Azure resources, see [Configure managed identities for Azure resources](/azure/active-directory/managed-identities-azure-resources/qs-configure-cli-windows-vm) and [Use managed identities for Azure resources for sign in](/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-sign-in).


### PR DESCRIPTION
Tested on a vm, if the vm has 2 user assigned managed identities and no system assigned identity, use `az login --identity` without `--username` will get the following error:

> Failed to connect to MSI. Please make sure MSI is configured correctly. Get Token request returned http error: 400, reason: Bad Request

This is mentioned in [Use managed identities on VMs - Get a token using HTTP](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http).

A test for the vm that has 2 user assigned managed identities plus system assigned identity showed that `az login --identity` will login with the system assigned idenity, thus `--username` is not required in this case.

The doc is modified accordingly based on the above results.