### PR TITLE
remove .md extension from absolute link

### DIFF
--- a/docs-ref-conceptual/includes/az-upgrade.md
+++ b/docs-ref-conceptual/includes/az-upgrade.md
@@ -13,6 +13,6 @@ az upgrade
 
 > [!NOTE]
 >
-> The `az upgrade` command was added in version 2.11.0 and will not work with versions prior to 2.11.0. Older versions can be updated by reinstalling as described in [Install the Azure CLI](/cli/azure/install-azure-cli.md).
+> The `az upgrade` command was added in version 2.11.0 and will not work with versions prior to 2.11.0. Older versions can be updated by reinstalling as described in [Install the Azure CLI](/cli/azure/install-azure-cli).
 >
 > This command will also update all installed extensions by default. For more `az upgrade` options, please refer to the [command reference page](/cli/azure/reference-index#az_upgrade).


### PR DESCRIPTION
Somehow I missed this in my previous change. It looks like the Install the Azure CLI link on https://review.docs.microsoft.com/en-us/cli/azure/update-azure-cli is broken.