### PR TITLE
Update SLES 12 install troubleshooting

### DIFF
--- a/docs-ref-conceptual/includes/cli-install-linux-zypper.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-zypper.md
@@ -76,32 +76,15 @@ sudo zypper rm -y --clean-deps azure-cli
 
 On SLES 12, the default `python3` package is `3.4` and not supported by Azure CLI. You can first follow step 1-3 of the [install instruction](#install) to add the `azure-cli` repository. Then build a higher version `python3` from source. Finally, you can download the Azure CLI package and install it without dependency.
 
-You can use the following one command to install Azure CLI (be aware that your existing Python 3 version will be overridden by Python 3.6):
+You can use the following one command to install or update Azure CLI based on above steps. The script will install `Python 3.8` under `/usr/local/azcli` and use Azure CLI with it by setting an alias of `az` to `PATH=/usr/local/azcli/bin:$PATH az`. You can also download the script and modify it according to your needs. For instance, you can change the Python version or install location.
 
 ```bash
-curl -sL https://azurecliprod.blob.core.windows.net/sles12_install.sh | sudo bash
+curl -sL https://azurecliprod.blob.core.windows.net/sles12_install_v2.sh | sudo bash
 ```
-
-Or you can do it step by step:
+For the first time install, remember to run the following command to activate the alias:
 
 ```bash
-# !Please add azure-cli repository first following step 1-3 of the install instruction before running below commands
-$ sudo zypper refresh
-$ sudo zypper install -y gcc gcc-c++ make ncurses patch wget tar zlib-devel zlib openssl-devel
-# Download Python source code
-$ PYTHON_VERSION="3.6.9"
-$ PYTHON_SRC_DIR=$(mktemp -d)
-$ wget -qO- https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz | tar -xz -C "$PYTHON_SRC_DIR"
-# Build Python
-# Please be aware that with --prefix=/usr, the command will override the existing Python 3 version
-$ $PYTHON_SRC_DIR/*/configure --prefix=/usr
-$ make
-$ sudo make install
-# Download azure-cli package 
-$ AZ_VERSION=$(zypper --no-refresh info azure-cli |grep Version | awk -F': ' '{print $2}' | awk '{$1=$1;print}')
-$ wget https://packages.microsoft.com/yumrepos/azure-cli/azure-cli-$AZ_VERSION.x86_64.rpm
-# Install without dependency
-$ sudo rpm -ivh --nodeps azure-cli-$AZ_VERSION.x86_64.rpm
+source ~/.bashrc
 ```
 
 ### Proxy blocks connection

--- a/docs-ref-conceptual/includes/cli-install-linux-zypper.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-zypper.md
@@ -76,7 +76,7 @@ sudo zypper rm -y --clean-deps azure-cli
 
 On SLES 12, the default `python3` package is `3.4` and not supported by Azure CLI. You can first follow step 1-3 of the [install instruction](#install) to add the `azure-cli` repository. Then build a higher version `python3` from source. Finally, you can download the Azure CLI package and install it without dependency.
 
-You can use the following one command to install or update Azure CLI based on above steps. The script will install `Python 3.8` under `/usr/local/azcli` and use Azure CLI with it by setting an alias of `az` to `PATH=/usr/local/azcli/bin:$PATH az`. You can also download the script and modify it according to your needs. For instance, you can change the Python version or install location.
+You can use the following one command to install or update Azure CLI based on above steps. The script will install `Python 3.8` under `/usr/local/azcli` and make Azure CLI use it by setting an alias of `az` to `PATH=/usr/local/azcli/bin:$PATH az`. You can also download the script and modify it according to your needs. For instance, you can change the Python version or install location.
 
 ```bash
 curl -sL https://azurecliprod.blob.core.windows.net/sles12_install_v2.sh | sudo bash


### PR DESCRIPTION
Update the script for sles 12 so that a new python 3 will be installed in a differrent location that will not overwrite the system default python 3.4.