### PR TITLE
Update install-azure-cli-beta.md

### DIFF
--- a/docs-ref-conceptual/install-azure-cli-beta.md
+++ b/docs-ref-conceptual/install-azure-cli-beta.md
@@ -64,7 +64,7 @@ To avoid overwriting your installed Azure CLI, we recommend installing the beta 
       ### [Windows PowerShell](#tab/powershell)
 
    ```powershell
-   . .\$env\Scripts\Activate.ps1
+   . .\<env_name>\Scripts\Activate.ps1
    ```
 
    ### [Linux/macOS Bash](#tab/bash)


### PR DESCRIPTION
I found the example of activating a python virtual environment could be confusing to PowerShell users, because `$env`  is the standard way of referencing environment variables in PowerShell, see [About Environment Variables](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-7.1#using-and-changing-environment-variables).

I changed it to  `<env_name>` as
1. it's less misleading
2. this is the same format in the example of creating virtual environment