### PR TITLE
YAML human-readable instead of machine-readable

### DIFF
--- a/docs-ref-conceptual/format-output-azure-cli.md
+++ b/docs-ref-conceptual/format-output-azure-cli.md
@@ -19,7 +19,7 @@ to format CLI output. The argument values and types of output are:
 ---------|-------------------------------
 `json`   | JSON string. This setting is the default
 `jsonc`  | Colorized JSON
-`yaml`   | YAML, a machine-readable alternative to JSON
+`yaml`   | YAML, a human-readable alternative to JSON
 `table`  | ASCII table with keys as column headings
 `tsv`    | Tab-separated values, with no keys
 `none`   | No output other than errors and warnings


### PR DESCRIPTION
Correcting YAML description to human-readable instead of machine-readable.  This resolves GitHub issue 2630 (https://github.com/MicrosoftDocs/azure-docs-cli/issues/2630).