### PR TITLE
Removed az create pr completion options

### DIFF
--- a/latest/docs-ref-autogen/repos/pr.yml
+++ b/latest/docs-ref-autogen/repos/pr.yml
@@ -31,40 +31,23 @@ directCommands:
   description: ''
   syntax: >-
     az repos pr create [--auto-complete {false, true}]
-                       [--bypass-policy {false, true}]
-                       [--bypass-policy-reason]
-                       [--delete-source-branch {false, true}]
                        [--description]
                        [--detect {false, true}]
                        [--draft {false, true}]
-                       [--merge-commit-message]
                        [--open]
                        [--org]
                        [--project]
                        [--repository]
                        [--reviewers]
                        [--source-branch]
-                       [--squash {false, true}]
                        [--subscription]
                        [--target-branch]
                        [--title]
-                       [--transition-work-items {false, true}]
                        [--work-items]
   optionalParameters:
   - name: --auto-complete
     parameterValueGroup: false, true
     summary: Set the pull request to complete automatically when all policies have passed and the source branch can be merged into the target branch.
-    description: ''
-  - name: --bypass-policy
-    parameterValueGroup: false, true
-    summary: Bypass required policies (if any) and completes the pull request once it can be merged.
-    description: ''
-  - name: --bypass-policy-reason
-    summary: Reason for bypassing the required policies.
-    description: ''
-  - name: --delete-source-branch
-    parameterValueGroup: false, true
-    summary: Delete the source branch after the pull request has been completed and merged into the target branch.
     description: ''
   - name: --description -d
     summary: 'Description for the new pull request. Can include markdown. Each value sent to this arg will be a new line. For example: --description "First Line" "Second Line".'
@@ -76,9 +59,6 @@ directCommands:
   - name: --draft
     parameterValueGroup: false, true
     summary: Use this flag to create the pull request in draft/work in progress mode.
-    description: ''
-  - name: --merge-commit-message
-    summary: Message displayed when commits are merged.
     description: ''
   - name: --open
     summary: Open the pull request in your web browser.
@@ -98,10 +78,6 @@ directCommands:
   - name: --source-branch -s
     summary: 'Name of the source branch. Example: "dev".'
     description: ''
-  - name: --squash
-    parameterValueGroup: false, true
-    summary: Squash the commits in the source branch when merging into the target branch.
-    description: ''
   - name: --subscription
     summary: Name or ID of subscription. You can configure the default subscription using `az account set -s NAME_OR_ID`.
     description: ''
@@ -110,10 +86,6 @@ directCommands:
     description: ''
   - name: --title
     summary: Title for the new pull request.
-    description: ''
-  - name: --transition-work-items
-    parameterValueGroup: false, true
-    summary: Transition any work items linked to the pull request into the next logical state. (e.g. Active -> Resolved).
     description: ''
   - name: --work-items
     summary: IDs of the work items to link to the new pull request. Space separated.


### PR DESCRIPTION
Cx found command that doesn't work. After some investigation, found out that PR Create controller that is used by az repos pr
create command never had this functionality. Only Update PR API can do such things. So completionOptions info should be deleted from docs

[Internal ticket with extra info link](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1875049/)

[Responsible service link](https://dev.azure.com/mseng/AzureDevOps/_git/AzureDevOps?path=/Tfs/Service/Git/Server/Services/PullRequest/TeamFoundationGitPullRequestService.Core.cs&_a=contents&version=GBmaster)
[Controller link](https://dev.azure.com/mseng/AzureDevOps/_git/AzureDevOps?path=%2fTfs%2fService%2fSourceControl%2fWeb%2fServer%2fControllers%2fGit%2fPullRequest%2fGitPullRequestsController.cs&version=GCae5e9e4aa0d285407105b7d7acf92ead86d32e35)