### PR TITLE
Install CLI on ARM64 with pip

### DIFF
--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -18,8 +18,13 @@ The `apt` package manager contains an x86_64 package for the Azure CLI that has 
 
 > [!WARNING]
 > Ubuntu 20.04 (Focal Fossa) and 20.10 (Groovy Gorilla) include an `azure-cli` package with version `2.0.81` provided by the `universe` repository. This package is outdated and not recommended. If this package is installed, remove the package before continuing by running the command `sudo apt remove azure-cli -y && sudo apt autoremove -y`.
+
+> [!NOTE]
+> The `azure-cli` deb package does not support ARM64 architecture. Currently the only way to use Azure CLI on ARM64 is to install from PyPI (https://pypi.org/project/azure-cli/):
 >
-> The `azure-cli` deb package does not support ARM64 architecture.
+>```bash
+>pip install azure-cli
+>```
 
 ## Installation Options
 


### PR DESCRIPTION
*Moved ARM64 line into its own Note box for easier scanability
*Added a recommendation for installing CLI on ARM64 based on conversations in https://github.com/Azure/azure-cli/issues/7368 and https://github.com/MicrosoftDocs/azure-docs/issues/80763