### PR TITLE
Add instruction for installing specific version

### DIFF
--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -85,8 +85,6 @@ You must first configure `azure-cli` repository information as shown above.
     sudo apt-get install azure-cli=<version>-1~bullseye
     ```
 
-[!INCLUDE [interactive-login](interactive-login.md)]
-
 ## Troubleshooting
 
 Here are some common problems seen when installing with `apt`. If you experience a problem not covered here, [file an issue on github](https://github.com/Azure/azure-cli/issues).

--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -73,17 +73,17 @@ If you prefer a step-by-step installation process, complete the following steps 
 
 You must first configure `azure-cli` repository information as shown above.
 
-To view available versions:
+1. To view available versions:
 
-```bash
-apt-cache policy azure-cli
-```
+    ```bash
+    apt-cache policy azure-cli
+    ```
 
-To install specific version:
+2. To install specific version:
 
-```bash
-sudo apt-get install azure-cli=2.29.1-1~bullseye
-```
+    ```bash
+    sudo apt-get install azure-cli=2.29.1-1~bullseye
+    ```
 
 [!INCLUDE [interactive-login](interactive-login.md)]
 

--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -69,13 +69,23 @@ If you prefer a step-by-step installation process, complete the following steps 
     sudo apt-get install azure-cli
     ```
 
-## Sign in to Azure with the Azure CLI
+## Install specific version
 
-Run the Azure CLI with the `az` command. To sign in, use the [az login](/cli/azure/reference-index#az_login) command.
+You must first configure `azure-cli` repository information as shown above.
+
+To view available versions:
+
+```bash
+apt-cache policy azure-cli
+```
+
+To install specific version:
+
+```bash
+sudo apt-get install azure-cli=2.29.1-1~bullseye
+```
 
 [!INCLUDE [interactive-login](interactive-login.md)]
-
-To learn more about different authentication methods, see [Sign in with Azure CLI](../authenticate-azure-cli.md).
 
 ## Troubleshooting
 

--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -82,7 +82,7 @@ You must first configure `azure-cli` repository information as shown above.
 2. To install specific version:
 
     ```bash
-    sudo apt-get install azure-cli=2.29.1-1~bullseye
+    sudo apt-get install azure-cli=<version>-1~bullseye
     ```
 
 [!INCLUDE [interactive-login](interactive-login.md)]

--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -71,9 +71,9 @@ If you prefer a step-by-step installation process, complete the following steps 
 
 ## Install specific version
 
-You must first configure `azure-cli` repository information as shown above.
+You must first configure `azure-cli` repository information as shown above. Available versions can be found at [Azure CLI release notes](/cli/azure/release-notes-azure-cli).
 
-1. To view available versions:
+1. To view available versions with command:
 
     ```bash
     apt-cache policy azure-cli

--- a/docs-ref-conceptual/includes/cli-install-linux-dnf.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-dnf.md
@@ -49,17 +49,17 @@ for the Azure CLI. This package has been tested with RHEL 7.7, RHEL 8, Fedora 24
 
 You must first configure `azure-cli` repository information as shown above.
 
-To view available versions:
+1. To view available versions:
 
-```bash
-dnf --showduplicates list azure-cli
-```
+   ```bash
+   dnf list --showduplicates azure-cli
+   ```
 
-To install specific version:
+2. To install specific version:
 
-```bash
-sudo dnf install azure-cli-2.29.1-1.el7
-```
+   ```bash
+   sudo dnf install azure-cli-2.29.1-1.el7
+   ```
 
 [!INCLUDE [interactive-login](interactive-login.md)]
 

--- a/docs-ref-conceptual/includes/cli-install-linux-dnf.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-dnf.md
@@ -58,7 +58,7 @@ You must first configure `azure-cli` repository information as shown above.
 2. To install specific version:
 
    ```bash
-   sudo dnf install azure-cli-2.29.1-1.el7
+   sudo dnf install azure-cli-<version>-1.el7
    ```
 
 [!INCLUDE [interactive-login](interactive-login.md)]

--- a/docs-ref-conceptual/includes/cli-install-linux-dnf.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-dnf.md
@@ -47,9 +47,9 @@ for the Azure CLI. This package has been tested with RHEL 7.7, RHEL 8, Fedora 24
 
 ## Install specific version
 
-You must first configure `azure-cli` repository information as shown above.
+You must first configure `azure-cli` repository information as shown above. Available versions can be found at [Azure CLI release notes](/cli/azure/release-notes-azure-cli).
 
-1. To view available versions:
+1. To view available versions with command:
 
    ```bash
    dnf list --showduplicates azure-cli

--- a/docs-ref-conceptual/includes/cli-install-linux-dnf.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-dnf.md
@@ -61,8 +61,6 @@ You must first configure `azure-cli` repository information as shown above.
    sudo dnf install azure-cli-<version>-1.el7
    ```
 
-[!INCLUDE [interactive-login](interactive-login.md)]
-
 ## Troubleshooting
 
 Here are some common problems seen when installing with `dnf`. If you experience a problem not covered here, [file an issue on GitHub](https://github.com/Azure/azure-cli/issues).

--- a/docs-ref-conceptual/includes/cli-install-linux-dnf.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-dnf.md
@@ -44,13 +44,24 @@ for the Azure CLI. This package has been tested with RHEL 7.7, RHEL 8, Fedora 24
    ```bash
    sudo dnf install azure-cli
    ```
- 
-Run the Azure CLI with the `az` command. To sign in, use [az login](/cli/azure/reference-index#az_login) command.
 
+## Install specific version
+
+You must first configure `azure-cli` repository information as shown above.
+
+To view available versions:
+
+```bash
+dnf --showduplicates list azure-cli
+```
+
+To install specific version:
+
+```bash
+sudo dnf install azure-cli-2.29.1-1.el7
+```
 
 [!INCLUDE [interactive-login](interactive-login.md)]
-
-To learn more about different authentication methods, see [Sign in with Azure CLI](../authenticate-azure-cli.md).
 
 ## Troubleshooting
 

--- a/docs-ref-conceptual/includes/cli-install-linux-script.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-script.md
@@ -5,7 +5,7 @@ manager: barbkess
 ms.date: 12/15/2020
 ms.topic: include
 ms.service: azure-cli
-ms.devlang: azurecli 
+ms.devlang: azurecli
 ms.custom: devx-track-azurecli
 ---
 
@@ -36,12 +36,6 @@ curl -L https://aka.ms/InstallAzureCli | bash
 ```
 
 The script can also be downloaded and run locally. You may have to restart your shell in order for changes to take effect.
-
-You can then run the Azure CLI with the `az` command. To sign in, use [az login](/cli/azure/reference-index#az_login) command.
-
-[!INCLUDE [interactive-login](interactive-login.md)]
-
-To learn more about different authentication methods, see [Sign in with Azure CLI](../authenticate-azure-cli.md).
 
 ## Troubleshooting
 

--- a/docs-ref-conceptual/includes/cli-install-linux-zypper.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-zypper.md
@@ -5,7 +5,7 @@ manager: barbkess
 ms.date: 11/24/2020
 ms.topic: include
 ms.service: azure-cli
-ms.devlang: azurecli 
+ms.devlang: azurecli
 ms.custom: devx-track-azurecli
 ---
 
@@ -59,7 +59,7 @@ You must first configure `azure-cli` repository information first as shown above
 2. To install specific version:
 
    ```bash
-   sudo zypper install --from azure-cli azure-cli=2.29.1-1.el7
+   sudo zypper install --from azure-cli azure-cli=<version>-1.el7
    ```
 
 [!INCLUDE [interactive-login](interactive-login.md)]
@@ -120,7 +120,7 @@ allow HTTPS connections to the following addresses:
 
 ### SSL certificate problem
 
-When a certificate is broken or outdated on a machine, you may receive an error indicating that curl failed to verify the legitimacy of the server and therefore could not establish a secure connection.  Update your certificate to correct the problem.  
+When a certificate is broken or outdated on a machine, you may receive an error indicating that curl failed to verify the legitimacy of the server and therefore could not establish a secure connection.  Update your certificate to correct the problem.
 
 ```bach
 sudo zypper update-ca-certificates

--- a/docs-ref-conceptual/includes/cli-install-linux-zypper.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-zypper.md
@@ -62,8 +62,6 @@ You must first configure `azure-cli` repository information first as shown above
    sudo zypper install --from azure-cli azure-cli=<version>-1.el7
    ```
 
-[!INCLUDE [interactive-login](interactive-login.md)]
-
 ## Troubleshooting
 
 Here are some common problems seen when installing with `zypper`. If you experience a problem not covered here, [file an issue on GitHub](https://github.com/Azure/azure-cli/issues).

--- a/docs-ref-conceptual/includes/cli-install-linux-zypper.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-zypper.md
@@ -50,17 +50,17 @@ for the Azure CLI. This package has been tested with openSUSE Leap 15.1, and SLE
 
 You must first configure `azure-cli` repository information first as shown above.
 
-To view available versions:
+1. To view available versions:
 
-```bash
-zypper search --details --match-exact azure-cli
-```
+   ```bash
+   zypper search --details --match-exact azure-cli
+   ```
 
-To install specific version:
+2. To install specific version:
 
-```bash
-sudo zypper install --from azure-cli azure-cli=2.29.1-1.el7
-```
+   ```bash
+   sudo zypper install --from azure-cli azure-cli=2.29.1-1.el7
+   ```
 
 [!INCLUDE [interactive-login](interactive-login.md)]
 

--- a/docs-ref-conceptual/includes/cli-install-linux-zypper.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-zypper.md
@@ -48,7 +48,7 @@ for the Azure CLI. This package has been tested with openSUSE Leap 15.1, and SLE
 
 ## Install specific version
 
-You must first configure `azure-cli` repository information first as shown above. Available versions can be found at [Azure CLI release notes](/cli/azure/release-notes-azure-cli).
+You must first configure `azure-cli` repository information as shown above. Available versions can be found at [Azure CLI release notes](/cli/azure/release-notes-azure-cli).
 
 1. To view available versions with command:
 

--- a/docs-ref-conceptual/includes/cli-install-linux-zypper.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-zypper.md
@@ -48,9 +48,9 @@ for the Azure CLI. This package has been tested with openSUSE Leap 15.1, and SLE
 
 ## Install specific version
 
-You must first configure `azure-cli` repository information first as shown above.
+You must first configure `azure-cli` repository information first as shown above. Available versions can be found at [Azure CLI release notes](/cli/azure/release-notes-azure-cli).
 
-1. To view available versions:
+1. To view available versions with command:
 
    ```bash
    zypper search --details --match-exact azure-cli

--- a/docs-ref-conceptual/includes/cli-install-linux-zypper.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-zypper.md
@@ -46,11 +46,23 @@ for the Azure CLI. This package has been tested with openSUSE Leap 15.1, and SLE
 
    Input 2 to continue install by ignoring some of its dependencies.
 
-You can then run the Azure CLI with the `az` command. To sign in, use [az login](/cli/azure/reference-index#az_login) command.
+## Install specific version
+
+You must first configure `azure-cli` repository information first as shown above.
+
+To view available versions:
+
+```bash
+zypper search --details --match-exact azure-cli
+```
+
+To install specific version:
+
+```bash
+sudo zypper install --from azure-cli azure-cli=2.29.1-1.el7
+```
 
 [!INCLUDE [interactive-login](interactive-login.md)]
-
-To learn more about different authentication methods, see [Sign in with Azure CLI](../authenticate-azure-cli.md).
 
 ## Troubleshooting
 

--- a/docs-ref-conceptual/includes/interactive-login.md
+++ b/docs-ref-conceptual/includes/interactive-login.md
@@ -5,6 +5,10 @@ manager: carmonm
 ms.date: 09/07/2018
 ms.topic: include
 ---
+## Sign in to Azure with the Azure CLI
+
+You can then run the Azure CLI with the `az` command. To sign in, use [`az login`](/cli/azure/reference-index#az_login) command.
+
 1. Run the `login` command.
 
     ```azurecli-interactive
@@ -19,3 +23,5 @@ ms.topic: include
     If no web browser is available or the web browser fails to open, use device code flow with **az login --use-device-code**.
 
 2. Sign in with your account credentials in the browser.
+
+To learn more about different authentication methods, see [Sign in with Azure CLI](../authenticate-azure-cli.md).

--- a/docs-ref-conceptual/includes/interactive-login.md
+++ b/docs-ref-conceptual/includes/interactive-login.md
@@ -5,10 +5,6 @@ manager: carmonm
 ms.date: 09/07/2018
 ms.topic: include
 ---
-## Sign in to Azure with the Azure CLI
-
-You can then run the Azure CLI with the `az` command. To sign in, use [`az login`](/cli/azure/reference-index#az_login) command.
-
 1. Run the `login` command.
 
     ```azurecli-interactive
@@ -23,5 +19,3 @@ You can then run the Azure CLI with the `az` command. To sign in, use [`az login
     If no web browser is available or the web browser fails to open, use device code flow with **az login --use-device-code**.
 
 2. Sign in with your account credentials in the browser.
-
-To learn more about different authentication methods, see [Sign in with Azure CLI](../authenticate-azure-cli.md).

--- a/docs-ref-conceptual/install-azure-cli-macos.md
+++ b/docs-ref-conceptual/install-azure-cli-macos.md
@@ -7,7 +7,7 @@ manager: barbkess
 ms.date: 08/19/2021
 ms.topic: conceptual
 ms.service: azure-cli
-ms.devlang: azurecli 
+ms.devlang: azurecli
 ms.custom: devx-track-azurecli, seo-azure-cli
 keywords: Install azure cli, azure cli macos, macos cli, install azure cli macos
 ---
@@ -37,8 +37,6 @@ brew update && brew install azure-cli
 > The Azure CLI has a dependency on the Homebrew `python3` package, and will install it.
 > The Azure CLI is guaranteed to be compatible with the latest version of `python3`
 > published on Homebrew.
-
-[!INCLUDE [interactive-login](includes/interactive-login.md)]
 
 ## Troubleshooting
 

--- a/docs-ref-conceptual/install-azure-cli-macos.md
+++ b/docs-ref-conceptual/install-azure-cli-macos.md
@@ -38,15 +38,6 @@ brew update && brew install azure-cli
 > The Azure CLI is guaranteed to be compatible with the latest version of `python3`
 > published on Homebrew.
 
-## Install specific version
-
-To install specific version:
-
-```bash
-curl -L https://raw.githubusercontent.com/azclibot/homebrew-core/azcli2.29.1/Formula/azure-cli.rb > azure-cli.rb
-brew install --build-from-source azure-cli.rb
-```
-
 [!INCLUDE [interactive-login](includes/interactive-login.md)]
 
 ## Troubleshooting

--- a/docs-ref-conceptual/install-azure-cli-macos.md
+++ b/docs-ref-conceptual/install-azure-cli-macos.md
@@ -38,11 +38,16 @@ brew update && brew install azure-cli
 > The Azure CLI is guaranteed to be compatible with the latest version of `python3`
 > published on Homebrew.
 
-You can then run the Azure CLI with the `az` command. To sign in, use [az login](/cli/azure/reference-index#az_login) command.
+## Install specific version
+
+To install specific version:
+
+```bash
+curl -L https://raw.githubusercontent.com/azclibot/homebrew-core/azcli2.29.1/Formula/azure-cli.rb > azure-cli.rb
+brew install --build-from-source azure-cli.rb
+```
 
 [!INCLUDE [interactive-login](includes/interactive-login.md)]
-
-To learn more about different authentication methods, see [Sign in with Azure CLI](authenticate-azure-cli.md).
 
 ## Troubleshooting
 

--- a/docs-ref-conceptual/install-azure-cli-windows.md
+++ b/docs-ref-conceptual/install-azure-cli-windows.md
@@ -40,7 +40,7 @@ Download and install the current release of the Azure CLI.  After the installati
 
 ### Specific version
 
-To download the MSI installer for specific version, change the version segment in URL `https://azcliprod.blob.core.windows.net/msi/azure-cli-<version>.msi` and download it.
+To download the MSI installer for specific version, change the version segment in URL `https://azcliprod.blob.core.windows.net/msi/azure-cli-<version>.msi` and download it. Available versions can be found at [Azure CLI release notes](/cli/azure/release-notes-azure-cli).
 
 ### Azure CLI beta version
 
@@ -63,7 +63,7 @@ Start PowerShell as administrator and run the following command:
 
 This will download and install the latest version of the Azure CLI for Windows. If you already have a version installed, the installer will update the existing version.
 
-To install specific version, replace the `-Uri` argument with `https://azcliprod.blob.core.windows.net/msi/azure-cli-<version>.msi` with version segment changed.
+To install specific version, replace the `-Uri` argument with `https://azcliprod.blob.core.windows.net/msi/azure-cli-<version>.msi` with version segment changed. Available versions can be found at [Azure CLI release notes](/cli/azure/release-notes-azure-cli).
 
 > [!Note]
 > After the installation is complete, you will need to reopen PowerShell to use the Azure CLI.

--- a/docs-ref-conceptual/install-azure-cli-windows.md
+++ b/docs-ref-conceptual/install-azure-cli-windows.md
@@ -8,14 +8,14 @@ ms.prod: azure
 ms.date: 08/19/2021
 ms.topic: conceptual
 ms.devlang: azurecli
-ms.technology: azure-cli 
+ms.technology: azure-cli
 ms.custom: devx-track-azurecli, seo-azure-cli
 keywords: Install azure cli, azure cli download, cli for windows, install azure cli on windows, azure cli windows, install azure cli windows
 ---
 
 # Install Azure CLI on Windows
 
-The Azure Command-Line Interface (CLI) is a cross-platform command-line tool that can be installed locally on Windows computers. You can use the Azure CLI for Windows to connect to Azure and execute administrative commands on Azure resources. The Azure CLI for Windows can also be used from a browser through the Azure Cloud Shell or run from inside a Docker container. 
+The Azure Command-Line Interface (CLI) is a cross-platform command-line tool that can be installed locally on Windows computers. You can use the Azure CLI for Windows to connect to Azure and execute administrative commands on Azure resources. The Azure CLI for Windows can also be used from a browser through the Azure Cloud Shell or run from inside a Docker container.
 
 For Windows, the Azure CLI is installed via a MSI, which gives you access to the CLI through the Windows Command Prompt (CMD) or PowerShell.
 When installing for Windows Subsystem for Linux (WSL), packages are available for your Linux distribution. See the [main install page](install-azure-cli.md)
@@ -40,11 +40,11 @@ Download and install the current release of the Azure CLI.  After the installati
 
 ### Specific version
 
-To download the MSI installer for specific version, change the version segment in URL https://azcliprod.blob.core.windows.net/msi/azure-cli-2.29.1.msi and download it.
+To download the MSI installer for specific version, change the version segment in URL `https://azcliprod.blob.core.windows.net/msi/azure-cli-<version>.msi` and download it.
 
 ### Azure CLI beta version
 
-The beta version of the Azure CLI supports all commands and will stay in sync with the current released version.  For installation instructions, see [Install Azure CLI beta version](install-azure-cli-beta.md). 
+The beta version of the Azure CLI supports all commands and will stay in sync with the current released version.  For installation instructions, see [Install Azure CLI beta version](install-azure-cli-beta.md).
 
 # [Microsoft Installer (MSI) with Command](#tab/azure-powershell)
 
@@ -63,7 +63,7 @@ Start PowerShell as administrator and run the following command:
 
 This will download and install the latest version of the Azure CLI for Windows. If you already have a version installed, the installer will update the existing version.
 
-To install specific version, replace the `-Uri` argument with https://azcliprod.blob.core.windows.net/msi/azure-cli-2.29.1.msi with version segment changed.
+To install specific version, replace the `-Uri` argument with `https://azcliprod.blob.core.windows.net/msi/azure-cli-<version>.msi` with version segment changed.
 
 > [!Note]
 > After the installation is complete, you will need to reopen PowerShell to use the Azure CLI.

--- a/docs-ref-conceptual/install-azure-cli-windows.md
+++ b/docs-ref-conceptual/install-azure-cli-windows.md
@@ -31,12 +31,16 @@ The MSI distributable is used for installing or updating the Azure CLI on Window
 
 When the installer asks if it can make changes to your computer, click the "Yes" box.
 
-### Azure CLI current version
+### Current version
 
 Download and install the current release of the Azure CLI.  After the installation is complete, you will need to close and reopen any active Windows Command Prompt or PowerShell windows to use the Azure CLI.
 
 > [!div class="nextstepaction"]
 > [Current release of the Azure CLI](https://aka.ms/installazurecliwindows)
+
+### Specific version
+
+To download the MSI installer for specific version, change the version segment in URL https://azcliprod.blob.core.windows.net/msi/azure-cli-2.29.1.msi and download it.
 
 ### Azure CLI beta version
 
@@ -58,6 +62,8 @@ Start PowerShell as administrator and run the following command:
    ```
 
 This will download and install the latest version of the Azure CLI for Windows. If you already have a version installed, the installer will update the existing version.
+
+To install specific version, replace the `-Uri` argument with https://azcliprod.blob.core.windows.net/msi/azure-cli-2.29.1.msi with version segment changed.
 
 > [!Note]
 > After the installation is complete, you will need to reopen PowerShell to use the Azure CLI.

--- a/docs-ref-conceptual/install-azure-cli-windows.md
+++ b/docs-ref-conceptual/install-azure-cli-windows.md
@@ -75,12 +75,7 @@ To install specific version, replace the `-Uri` argument with `https://azcliprod
 
 ## Run the Azure CLI
 
-You can now run the Azure CLI with the `az` command from either Windows Command Prompt or PowerShell. PowerShell offers some tab completion features
-not available from Windows Command Prompt. To sign in, run the [az login](/cli/azure/reference-index#az_login) command.
-
-[!INCLUDE [interactive-login](includes/interactive-login.md)]
-
-To learn more about different authentication methods, see [Sign in with Azure CLI](authenticate-azure-cli.md).
+You can now run the Azure CLI with the `az` command from either Windows Command Prompt or PowerShell.
 
 ## Troubleshooting
 

--- a/docs-ref-conceptual/run-azure-cli-docker.md
+++ b/docs-ref-conceptual/run-azure-cli-docker.md
@@ -20,7 +20,7 @@ with an isolated environment to run the CLI in. The image can also be used as a 
 ## Install Azure CLI in Docker
 
 > [!NOTE]
-> The Azure CLI has migrated to [Microsoft Container Registry](https://azure.microsoft.com/services/container-registry). 
+> The Azure CLI has migrated to [Microsoft Container Registry](https://azure.microsoft.com/services/container-registry).
 > Existing tags on Docker Hub are still supported, but new releases will only be available as mcr.microsoft.com/azure-cli.
 
 Install the CLI using `docker run`.
@@ -42,7 +42,7 @@ Install the CLI using `docker run`.
 To install specific version:
 
 ```bash
-docker run -it mcr.microsoft.com/azure-cli:2.29.1
+docker run -it mcr.microsoft.com/azure-cli:<version>
 ```
 
 [!INCLUDE [interactive-login](includes/interactive-login.md)]

--- a/docs-ref-conceptual/run-azure-cli-docker.md
+++ b/docs-ref-conceptual/run-azure-cli-docker.md
@@ -37,6 +37,8 @@ Install the CLI using `docker run`.
 > docker run -it -v ${HOME}/.ssh:/root/.ssh mcr.microsoft.com/azure-cli
 > ```
 
+The CLI is installed on the image as the `az` command in `/usr/local/bin`.
+
 ## Install specific version
 
 To install specific version:
@@ -44,8 +46,6 @@ To install specific version:
 ```bash
 docker run -it mcr.microsoft.com/azure-cli:<version>
 ```
-
-[!INCLUDE [interactive-login](includes/interactive-login.md)]
 
 ## Update Docker image
 

--- a/docs-ref-conceptual/run-azure-cli-docker.md
+++ b/docs-ref-conceptual/run-azure-cli-docker.md
@@ -37,11 +37,15 @@ Install the CLI using `docker run`.
 > docker run -it -v ${HOME}/.ssh:/root/.ssh mcr.microsoft.com/azure-cli
 > ```
 
-The CLI is installed on the image as the `az` command in `/usr/local/bin`. To sign in, run the [az login](/cli/azure/reference-index#az_login) command.
+## Install specific version
+
+To install specific version:
+
+```bash
+docker run -it mcr.microsoft.com/azure-cli:2.29.1
+```
 
 [!INCLUDE [interactive-login](includes/interactive-login.md)]
-
-To learn more about different authentication methods, see [Sign in with the Azure CLI](authenticate-azure-cli.md).
 
 ## Update Docker image
 

--- a/docs-ref-conceptual/run-azure-cli-docker.md
+++ b/docs-ref-conceptual/run-azure-cli-docker.md
@@ -41,6 +41,8 @@ The CLI is installed on the image as the `az` command in `/usr/local/bin`.
 
 ## Install specific version
 
+Available versions can be found at [Azure CLI release notes](/cli/azure/release-notes-azure-cli).
+
 To install specific version:
 
 ```bash


### PR DESCRIPTION
This PR is based on https://github.com/Azure/azure-cli/issues/13331#issuecomment-635446175.

There are scenarios where the latest Azure CLI 

- doesn't satisfy users' needs 
- introduces breaking changes that users are not yet ready to adopt to
- contains bugs that can't be fixed immediately

To address these scenarios, we provide the instruction for installing specific version.