### PR TITLE
(AzureCXP) Fixes MicrosoftDocs/azure-docs-cli#2820

### DIFF
--- a/docs-ref-conceptual/format-output-azure-cli.md
+++ b/docs-ref-conceptual/format-output-azure-cli.md
@@ -213,7 +213,8 @@ What default output format would you like?
  [3] table - Human-readable output format.
  [4] tsv - Tab- and Newline-delimited. Great for GREP, AWK, etc.
  [5] yaml - YAML formatted output. An alternative to JSON. Great for configuration files.
- [6] none - No output, except for errors and warnings.
+ [6] yamlc - Colored YAML formatted output. An alternative to JSON. Great for configuration files.
+ [7] none - No output, except for errors and warnings.
 Please enter a choice [1]:
 ```
 

--- a/docs-ref-conceptual/format-output-azure-cli.md
+++ b/docs-ref-conceptual/format-output-azure-cli.md
@@ -4,7 +4,7 @@ description: The Azure CLI offers various output formats such as JSON and YAML. 
 author: dbradish-microsoft
 ms.author: dbradish
 manager: barbkess
-ms.date: 08/19/2021
+ms.date: 11/11/2021
 ms.topic: conceptual
 ms.service: azure-cli
 ms.devlang: azurecli
@@ -21,6 +21,7 @@ to format CLI output. The argument values and types of output are:
 `json`   | JSON string. This setting is the default
 `jsonc`  | Colorized JSON
 `yaml`   | YAML, a human-readable alternative to JSON
+`yamlc`  | Colorized YAML
 `table`  | ASCII table with keys as column headings
 `tsv`    | Tab-separated values, with no keys
 `none`   | No output other than errors and warnings


### PR DESCRIPTION
Added entry for `yamlc` output format