### PR TITLE
Restore samples for Web Apps to the CLI TOC

### DIFF
--- a/docs-ref-conceptual/TOC.yml
+++ b/docs-ref-conceptual/TOC.yml
@@ -84,7 +84,7 @@
     href: /azure/virtual-machines/windows/cli-samples?toc=%2fcli%2fazure%2ftoc.json&bc=%2fcli%2fazure%2fbreadcrumb%2ftoc.json
     displayName: virtual machines
   - name: Web Apps
-    href: /azure/app-service-web/app-service-cli-samples?toc=%2fcli%2fazure%2ftoc.json&bc=%2fcli%2fazure%2fbreadcrumb%2ftoc.json
+    href: /azure/app-service/samples-cli?toc=%2fcli%2fazure%2ftoc.json&bc=%2fcli%2fazure%2fbreadcrumb%2ftoc.json
   - name: Functions
     href: /azure/azure-functions/functions-cli-samples?toc=%2fcli%2fazure%2ftoc.json&bc=%2fcli%2fazure%2fbreadcrumb%2ftoc.json
     displayName: serverless, lambda


### PR DESCRIPTION
Restore CLI samples for Azure App Service to the Azure CLI TOC.
1. Go to https://docs.microsoft.com/en-us/cli/azure/
2. Select Samples > Web Apps
3. Land on [CLI samples for Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/samples-cli?toc=%2Fcli%2Fazure%2Ftoc.json&bc=%2Fcli%2Fazure%2Fbreadcrumb%2Ftoc.json), but not in context of the Azure CLI TOC.

Likely due to the redirect added per: https://github.com/MicrosoftDocs/azure-docs-pr/blob/master/.openpublishing.redirection.json

{
  "source_path_from_root": "/articles/app-service-web/app-service-cli-samples.md",
  "redirect_url": "/azure/app-service/samples-cli",
  "redirect_document_id": false
},