### PR TITLE
Debian 11 (Bullseye) support

### DIFF
--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -13,7 +13,7 @@ The `apt` package manager contains an x86_64 package for the Azure CLI that has 
 
 | Distribution | Version |
 |:-------------|:--------|
-| Ubuntu       | 14.04 LTS (Trusty Tahir), 16.04 LTS (Xenial Xerus), 18.04 LTS (Bionic Beaver), 20.04 LTS (Focal Fossa), 20.10 (Groovy Gorilla) |
+| Ubuntu       | 14.04 LTS (Trusty Tahir), 16.04 LTS (Xenial Xerus), 18.04 LTS (Bionic Beaver), 20.04 LTS (Focal Fossa), 21.04 (Hirsute Hippo) |
 | Debian       | Debian 8 (Jessie), Debian 9 (Stretch), Debian 10 (Buster), Debian 11 (Bullseye) |
 
 > [!WARNING]

--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -14,7 +14,7 @@ The `apt` package manager contains an x86_64 package for the Azure CLI that has 
 | Distribution | Version |
 |:-------------|:--------|
 | Ubuntu       | 14.04 LTS (Trusty Tahir), 16.04 LTS (Xenial Xerus), 18.04 LTS (Bionic Beaver), 20.04 LTS (Focal Fossa), 20.10 (Groovy Gorilla) |
-| Debian       | Debian 8 (Jessie), Debian 9 (Stretch), Debian 10 (Buster) |
+| Debian       | Debian 8 (Jessie), Debian 9 (Stretch), Debian 10 (Buster), Debian 11 (Bullseye) |
 
 > [!WARNING]
 > Ubuntu 20.04 (Focal Fossa) and 20.10 (Groovy Gorilla) include an `azure-cli` package with version `2.0.81` provided by the `universe` repository. This package is outdated and not recommended. If this package is installed, remove the package before continuing by running the command `sudo apt remove azure-cli -y && sudo apt autoremove -y`.


### PR DESCRIPTION
According to the  apt repository, Debian 11 also supported.