### PR TITLE
Add warning for dropping Ubuntu 14.04 (Trusty Tahir) and Debian 8 (Jessie) support

### DIFF
--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -17,6 +17,9 @@ The `apt` package manager contains an x86_64 package for the Azure CLI that has 
 | Debian       | Debian 8 (Jessie), Debian 9 (Stretch), Debian 10 (Buster), Debian 11 (Bullseye) |
 
 > [!WARNING]
+> Starting from Azure CLI 2.34.0, no DEB packages will be released for Ubuntu 14.04 (Trusty Tahir) and Debian 8 (Jessie). You may continue to use historical versions of Azure CLI on these systems, but there will be no updates or bugfixes. Consider upgrading to newer versions of Ubuntu or Debian to use the latest Azure CLI.
+
+> [!WARNING]
 > Ubuntu 20.04 (Focal Fossa) and 20.10 (Groovy Gorilla) include an `azure-cli` package with version `2.0.81` provided by the `universe` repository. This package is outdated and not recommended. If this package is installed, remove the package before continuing by running the command `sudo apt remove azure-cli -y && sudo apt autoremove -y`.
 >
 > The `azure-cli` deb package does not support ARM64 architecture.


### PR DESCRIPTION
Since Python 3.6 has reached its end-of-line, I am trying to bump embedded Python to 3.8 for deb packages (https://github.com/Azure/azure-cli/pull/20869). During that, I found Python 3.8 can't be built on Ubuntu 14.04 (Trusty Tahir) and Debian 8 (Jessie) (https://github.com/Azure/azure-cli/pull/20869#issuecomment-1002892600).

In order to move away from Python 3.6, Ubuntu 14.04 (Trusty Tahir) and Debian 8 (Jessie) support should be dropped.

