### PR TITLE
[BrokenLinksH2] found a broken link

### DIFF
--- a/docs-ref-conceptual/azure-cli-reference-for-data-share.md
+++ b/docs-ref-conceptual/azure-cli-reference-for-data-share.md
@@ -31,7 +31,7 @@ List of Azure Data Share CLI references that can be used to manage Azure Data Sh
 | [az datashare dataset](/cli/azure/datashare/dataset) | Commands for providers to manage Azure Data Share datasets.
 | [az datashare invitation](/cli/azure/datashare/invitation) | Commands for consumers to manage Azure Data Share invitations.
 | [az datashare provider-share-subscription](/cli/azure/datashare/provider-share-subscription) | Commands for providers to manage Azure Data Share subscriptions.
-| [az datashare synchronization](/cli/azure/datashare/synchronization) | Commands to manage Azure Data Share synchronization.
+| [az datashare synchronization](/cli/azure/datashare) | Commands to manage Azure Data Share synchronization.
 | [az datashare synchronization-setting](/cli/azure/datashare/synchronization-setting) | Commands for providers to manage Azure Data Share synchronization settings.
 
 ## Reference examples


### PR DESCRIPTION
**Global effort to fix broken links**

@dbradish-microsoft 

The Content & Learning team is fixing broken links on docs.microsoft.com for the rest of H2. 

The link to "az datashare synchronization" is broken, and with extensive searching I have not been able to find a document to link it to.  There are plenty of commands that involve synchronization, but nothing on synchronization itself.  This is the best I can find.  Perhaps you have a better alternative?