### PR TITLE
[BrokenLinksH2] fixing broken link

### DIFF
--- a/docs-ref-conceptual/azure-cli-reference-for-monitor.md
+++ b/docs-ref-conceptual/azure-cli-reference-for-monitor.md
@@ -31,7 +31,7 @@ List of Azure CLI references that can be used to manage Azure Monitor, reference
 |-|-|-|-|
 | [az monitor](/cli/azure/monitor) | | The top-level command group for all Azure CLI commands for Azure Monitor. | [Azure Monitor overview](/azure/azure-monitor/overview)
 | [az monitor action-group](/cli/azure/monitor/action-group) | | Manage action groups, which relate to notifications once an alert has fired. | [Azure Monitor alerts](/azure/azure-monitor/platform/alerts-overview)
-| [az monitor action-rule](/cli/azure/monitor/action-rule) | yes | Manage action rules, which let you add or suppress the action groups on your fired alerts. | [Azure Monitor alerts](/azure/azure-monitor/alerts/alerts-action-rules)
+| [az monitor action-rule](/azure/azure-monitor/alerts/alerts-action-rules) | yes | Manage action rules, which let you add or suppress the action groups on your fired alerts. | [Azure Monitor alerts](/azure/azure-monitor/alerts/alerts-action-rules)
 | [az monitor activity-log](/cli/azure/monitor/activity-log) | | Manage activity logs, including activity log alerts. | [Azure activity logs](/azure/azure-monitor/platform/activity-log)
 | [az monitor app-insights](/cli/azure/monitor/app-insights) | yes | Manage Application Insights for application monitoring. | [Application insights overview](/azure/azure-monitor/app/app-insights-overview)
 | [az monitor autoscale](/cli/azure/monitor/autoscale) | | Manage autoscale settings. | [Autoscale overview](/azure/azure-monitor/platform/autoscale-overview)


### PR DESCRIPTION
**Global effort to fix broken links**

@dbradish-microsoft

The Content & Learning team is fixing broken links on docs.microsoft.com for the rest of H2. 

I've been searching for a direct replacement for this link, and this is the best I can find.  Perhaps you know a better one?

This effort will eliminate potential accessibility, security, and usability issues. This PR includes only link fixes and does not change other content. Please review within five business days and merge, or comment in the PR with any changes you'd like to see. Thanks!