### PR TITLE
Add Ubuntu 22.04 (Jammy Jellyfish) to supported distributions

### DIFF
--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -13,7 +13,7 @@ The `apt` package manager contains an x86_64 package for the Azure CLI that has 
 
 | Distribution | Version |
 |:-------------|:--------|
-| Ubuntu       | 16.04 LTS (Xenial Xerus), 18.04 LTS (Bionic Beaver), 20.04 LTS (Focal Fossa), 21.10 (Impish Indri) |
+| Ubuntu       | 16.04 LTS (Xenial Xerus), 18.04 LTS (Bionic Beaver), 20.04 LTS (Focal Fossa), 21.10 (Impish Indri), 22.04 (Jammy Jellyfish) |
 | Debian       | 9 (Stretch), 10 (Buster), 11 (Bullseye) |
 
 > [!WARNING]


### PR DESCRIPTION
Ubuntu 22.04 (Jammy Jellyfish) support is added by https://github.com/Azure/azure-cli/pull/21948