### PR TITLE
Add warning for dropping Ubuntu 16.04 (Xenial Xerus) and Debian 9 (Stretch) support

### DIFF
--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -17,7 +17,7 @@ The `apt` package manager contains an x86_64 package for the Azure CLI that has 
 | Debian       | 9 (Stretch), 10 (Buster), 11 (Bullseye) |
 
 > [!WARNING]
-> Starting from Azure CLI 2.34.0, no DEB packages are released for Ubuntu 14.04 (Trusty Tahir) and Debian 8 (Jessie). You may continue to use historical versions of Azure CLI on these systems, but there will be no updates or bugfixes. Consider upgrading to newer versions of Ubuntu or Debian to use the latest Azure CLI.
+> Starting from Azure CLI 2.37.0, no DEB packages will be released for Ubuntu 16.04 (Xenial Xerus) and Debian 9 (Stretch). You may continue to use historical versions of Azure CLI on these systems, but there will be no updates or bugfixes. Consider upgrading to newer versions of Ubuntu or Debian to use the latest Azure CLI.
 
 > [!WARNING]
 > Ubuntu 20.04 (Focal Fossa) and 20.10 (Groovy Gorilla) include an `azure-cli` package with version `2.0.81` provided by the `universe` repository. This package is outdated and not recommended. If this package is installed, remove the package before continuing by running the command `sudo apt remove azure-cli -y && sudo apt autoremove -y`.


### PR DESCRIPTION
Change doc according to https://github.com/Azure/azure-cli/pull/22170