### PR TITLE
Add doc for installing on Mariner

### DIFF
--- a/docs-ref-conceptual/includes/cli-install-linux-tdnf.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-tdnf.md
@@ -1,0 +1,54 @@
+---
+author: jiasli
+ms.author: jiasli
+manager: yonzhan
+ms.date: 04/29/2022
+ms.topic: include
+ms.custom: devx-track-azurecli
+---
+
+## Overview
+
+RPMs are released for [CBL-Mariner](https://github.com/microsoft/CBL-Mariner) 1.0 and 2.0.
+
+## Install
+
+Install with the `tdnf install` command:
+
+```bash
+sudo tdnf install azure-cli
+```
+
+## Install specific version
+
+Available versions can be found at [Azure CLI release notes](../release-notes-azure-cli.md).
+
+To view available versions with command:
+
+```bash
+tdnf list azure-cli
+```
+
+To install specific version:
+
+```bash
+sudo tdnf install azure-cli-<version>-1
+```
+
+## Update
+
+Update the Azure CLI with the `tdnf update` command:
+
+```bash
+sudo tdnf update azure-cli
+```
+
+## Uninstall
+
+[!INCLUDE [uninstall-boilerplate.md](uninstall-boilerplate.md)]
+
+Remove the package from your system:
+
+```bash
+sudo tdnf remove azure-cli
+```

--- a/docs-ref-conceptual/install-azure-cli-linux.md
+++ b/docs-ref-conceptual/install-azure-cli-linux.md
@@ -7,7 +7,7 @@ manager: yonzhan
 ms.date: 04/29/2022
 ms.topic: conceptual
 ms.service: azure-cli
-ms.devlang: azurecli 
+ms.devlang: azurecli
 ms.custom: devx-track-azurecli, seo-azure-cli
 zone_pivot_group_filename: azure/zone-pivot-groups.json
 zone_pivot_groups: cli-linux-installation-method
@@ -30,6 +30,12 @@ When you are ready to install the Azure CLI on Linux, it is recommended to use a
 ::: zone pivot="dnf"
 
 [!INCLUDE [cli-install-linux-apt](includes/cli-install-linux-dnf.md)]
+
+::: zone-end
+
+::: zone pivot="tdnf"
+
+[!INCLUDE [cli-install-linux-tdnf](includes/cli-install-linux-tdnf.md)]
 
 ::: zone-end
 

--- a/docs-ref-conceptual/zone-pivot-groups.yml
+++ b/docs-ref-conceptual/zone-pivot-groups.yml
@@ -8,6 +8,8 @@ groups:
       title: apt (Ubuntu, Debian)
     - id: dnf
       title: dnf (RHEL, Fedora, CentOS)
+    - id: tdnf
+      title: tdnf (Mariner)
     - id: zypper
       title: zypper (openSUSE, SLES)
     - id: script


### PR DESCRIPTION
Mariner 1.0 and 2.0 are now supported.

See https://github.com/Azure/azure-cli/pull/22034