### PR TITLE
Explicitly document Microsoft tenant's limitation on device code and Microsoft Graph

### DIFF
--- a/docs-ref-conceptual/microsoft-graph-migration.md
+++ b/docs-ref-conceptual/microsoft-graph-migration.md
@@ -88,7 +88,9 @@ If you are not ready for the migration yet, such as lacking Microsoft Graph perm
 
 ### Graph command fails with `AADSTS50005` or `AADSTS53000`
 
-Your tenant may have Conditional Access policies that blocks using device code flow to access Microsoft Graph. In such case, use authorization code flow or service principal to sign in instead. For more information about signing in methods, please see [Sign in with Azure CLI](authenticate-azure-cli.md).
+Your tenant may have Conditional Access policies that block using device code flow to access Microsoft Graph. In such case, use authorization code flow or service principal to sign in instead. For more information about signing in methods, please see [Sign in with Azure CLI](authenticate-azure-cli.md).
+
+Microsoft tenant (72f988bf-86f1-41af-91ab-2d7cd011db47) has such Conditional Access policies configured.
 
 ## Give feedback
 


### PR DESCRIPTION
Previously in https://github.com/MicrosoftDocs/azure-docs-cli/pull/3153, we didn't explicitly call out Microsoft tenant has such limitation, as we think https://github.com/Azure/azure-cli/issues/22629 is a common problem and we don't want external customers to be bothered with Microsoft internal business.

Now we are still seeing [internal tickets](https://portal.microsofticm.com/imp/v3/incidents/details/312884367/home) created for this issue, so let's explicitly call out that this issue happens for Microsoft internal users.
 

