### PR TITLE
Fix incorrect Azure CLI reference links

### DIFF
--- a/docs-ref-conceptual/azure-cli-support-request.md
+++ b/docs-ref-conceptual/azure-cli-support-request.md
@@ -26,7 +26,7 @@ To create a support request, you must be an [Owner](/azure/role-based-access-con
 
 ## Create a support ticket
 
-1. To obtain a list of services, use the [az support services list](/cli/azure/ext/support/support/services#ext_support_az_support_services_list) command:
+1. To obtain a list of services, use the [az support services list](/cli/azure/support/services#az_support_services_list) command:
 
    ```azurecli
    az support services list --output table
@@ -34,7 +34,7 @@ To create a support request, you must be an [Owner](/azure/role-based-access-con
 
    For this example, find the value for **Virtual Machine running Windows**, which is **6f16735c-b0ae-b275-ad3a-03479cfa1396**.
 
-1. To get the problem type and problem subtype that describes your problem, run the [az support services problem-classifications list](/cli/azure/ext/support/support/services/problem-classifications#ext_support_az_support_services_problem_classifications_list) command:
+1. To get the problem type and problem subtype that describes your problem, run the [az support services problem-classifications list](/cli/azure/support/services/problem-classifications#az_support_services_problem_classifications_list) command:
 
    ```azurecli
    az support services problem-classifications list --service-name 6f16735c-b0ae-b275-ad3a-03479cfa1396 --output table
@@ -42,7 +42,7 @@ To create a support request, you must be an [Owner](/azure/role-based-access-con
 
    For this example, find **Cannot connect to my VM / I have an issue with my public IP**. That type has a value of **e5c307e3-50ff-5dc9-c8ae-7d35051f88c9**.
 
-1. Create a ticket by using the [az support tickets create](/cli/azure/ext/support/support/tickets#ext_support_az_support_tickets_create) command:
+1. Create a ticket by using the [az support tickets create](/cli/azure/support/tickets#az_support_tickets_create) command:
 
    ```azurecli
    az support tickets create --ticket-name "VM012" --title "Issue with public IP" \
@@ -57,7 +57,7 @@ A support engineer will contact you using the method you indicated. For informat
 
 ## Manage support tickets
 
-The Azure CLI enables you to perform support ticket management using various commands. To see your Azure support tickets for your current subscription, run the [az support tickets list](/cli/azure/ext/support/support/tickets#ext_support_az_support_tickets_list) command:
+The Azure CLI enables you to perform support ticket management using various commands. To see your Azure support tickets for your current subscription, run the [az support tickets list](/cli/azure/support/tickets#az_support_tickets_list) command:
 
 ```azurecli
 az support tickets list
@@ -65,7 +65,7 @@ az support tickets list
 
 To see Azure support tickets in another subscription, run the [az account set](/cli/azure/account#az_account_set) command to change your current subscription, and then run the command.
 
-You can also update a ticket by using the [az support tickets update](/cli/azure/ext/support/support/tickets#ext_support_az_support_tickets_update) command:
+You can also update a ticket by using the [az support tickets update](/cli/azure/support/tickets#az_support_tickets_update) command:
 
 ```azurecli
 az support tickets update --ticket-name VM012 --severity moderate
@@ -75,7 +75,7 @@ az support tickets update --ticket-name VM012 --severity moderate
 
 You can't delete a support ticket created by using Azure CLI. Instead, send a message to close a ticket. If you need to reopen a closed support request, create a new message, which automatically reopens the request.
 
-To communicate about your ticket, run the [az support tickets communications create](/cli/azure/ext/support/support/tickets/communications#ext_support_az_support_tickets_communications_create) command:
+To communicate about your ticket, run the [az support tickets communications create](/cli/azure/support/tickets/communications#az_support_tickets_communications_create) command:
 
 ```azurecli
 az support tickets communications create --ticket-name VM012 \
@@ -84,7 +84,7 @@ az support tickets communications create --ticket-name VM012 \
     --communication-subject "Delaying VM fixes due to scheduling on our end."
 ```
 
-To see all the communications for a ticket, use the [az support tickets communications list](/cli/azure/ext/support/support/tickets/communications#ext_support_az_support_tickets_communications_list) command:
+To see all the communications for a ticket, use the [az support tickets communications list](/cli/azure/support/tickets/communications#az_support_tickets_communications_list) command:
 
 ```azurecli
 az support tickets communications list --ticket-name VM012

--- a/docs-ref-conceptual/azure-cli-support-request.md
+++ b/docs-ref-conceptual/azure-cli-support-request.md
@@ -26,7 +26,7 @@ To create a support request, you must be an [Owner](/azure/role-based-access-con
 
 ## Create a support ticket
 
-1. To obtain a list of services, use the [az support services list](/cli/azure/support/services#az_support_services_list) command:
+1. To obtain a list of services, use the [az support services list](/cli/azure/support/services#az-support-services-list) command:
 
    ```azurecli
    az support services list --output table
@@ -34,7 +34,7 @@ To create a support request, you must be an [Owner](/azure/role-based-access-con
 
    For this example, find the value for **Virtual Machine running Windows**, which is **6f16735c-b0ae-b275-ad3a-03479cfa1396**.
 
-1. To get the problem type and problem subtype that describes your problem, run the [az support services problem-classifications list](/cli/azure/support/services/problem-classifications#az_support_services_problem_classifications_list) command:
+1. To get the problem type and problem subtype that describes your problem, run the [az support services problem-classifications list](/cli/azure/support/services/problem-classifications#az-support-services-problem-classifications-list) command:
 
    ```azurecli
    az support services problem-classifications list --service-name 6f16735c-b0ae-b275-ad3a-03479cfa1396 --output table
@@ -42,7 +42,7 @@ To create a support request, you must be an [Owner](/azure/role-based-access-con
 
    For this example, find **Cannot connect to my VM / I have an issue with my public IP**. That type has a value of **e5c307e3-50ff-5dc9-c8ae-7d35051f88c9**.
 
-1. Create a ticket by using the [az support tickets create](/cli/azure/support/tickets#az_support_tickets_create) command:
+1. Create a ticket by using the [az support tickets create](/cli/azure/support/tickets#az-support-tickets-create) command:
 
    ```azurecli
    az support tickets create --ticket-name "VM012" --title "Issue with public IP" \
@@ -57,15 +57,15 @@ A support engineer will contact you using the method you indicated. For informat
 
 ## Manage support tickets
 
-The Azure CLI enables you to perform support ticket management using various commands. To see your Azure support tickets for your current subscription, run the [az support tickets list](/cli/azure/support/tickets#az_support_tickets_list) command:
+The Azure CLI enables you to perform support ticket management using various commands. To see your Azure support tickets for your current subscription, run the [az support tickets list](/cli/azure/support/tickets#az-support-tickets-list) command:
 
 ```azurecli
 az support tickets list
 ```
 
-To see Azure support tickets in another subscription, run the [az account set](/cli/azure/account#az_account_set) command to change your current subscription, and then run the command.
+To see Azure support tickets in another subscription, run the [az account set](/cli/azure/account#az-account-set) command to change your current subscription, and then run the command.
 
-You can also update a ticket by using the [az support tickets update](/cli/azure/support/tickets#az_support_tickets_update) command:
+You can also update a ticket by using the [az support tickets update](/cli/azure/support/tickets#az-support-tickets-update) command:
 
 ```azurecli
 az support tickets update --ticket-name VM012 --severity moderate
@@ -75,7 +75,7 @@ az support tickets update --ticket-name VM012 --severity moderate
 
 You can't delete a support ticket created by using Azure CLI. Instead, send a message to close a ticket. If you need to reopen a closed support request, create a new message, which automatically reopens the request.
 
-To communicate about your ticket, run the [az support tickets communications create](/cli/azure/support/tickets/communications#az_support_tickets_communications_create) command:
+To communicate about your ticket, run the [az support tickets communications create](/cli/azure/support/tickets/communications#az-support-tickets-communications-create) command:
 
 ```azurecli
 az support tickets communications create --ticket-name VM012 \
@@ -84,7 +84,7 @@ az support tickets communications create --ticket-name VM012 \
     --communication-subject "Delaying VM fixes due to scheduling on our end."
 ```
 
-To see all the communications for a ticket, use the [az support tickets communications list](/cli/azure/support/tickets/communications#az_support_tickets_communications_list) command:
+To see all the communications for a ticket, use the [az support tickets communications list](/cli/azure/support/tickets/communications#az-support-tickets-communications-list) command:
 
 ```azurecli
 az support tickets communications list --ticket-name VM012


### PR DESCRIPTION
Bulk update: Edit incorrect Azure CLI reference links by replacing underscores with dashes and removing /ext.

This work is in accordance with [User Story 1948095](https://dev.azure.com/mseng/TechnicalContent/_workitems/edit/1948095).
