### PR TITLE
Update microsoft-graph-migration.md: include `az ad app update`

### DIFF
--- a/docs-ref-conceptual/microsoft-graph-migration.md
+++ b/docs-ref-conceptual/microsoft-graph-migration.md
@@ -24,7 +24,7 @@ For example, the most outstanding change is that the `objectId` property in the 
 
 Command argument and behavior breaking changes are listed below.
 
-### `az ad app create`
+### `az ad app create/update`
 
 - Split `--reply-urls` into `--web-redirect-uris` and `--public-client-redirect-uris`
 - Replace `--homepage` with `--web-home-page-url`


### PR DESCRIPTION
`az ad app create` and `az ad app update` share the same parameters, so we should include `az ad app update` in the breaking change doc as well.

Close #3171