### PR TITLE
Add warning for dropping RHEL 7 and CentOS 7 RPMs

### DIFF
--- a/docs-ref-conceptual/includes/cli-install-linux-dnf.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-dnf.md
@@ -2,15 +2,17 @@
 author: dbradish-microsoft
 ms.author: dbradish
 manager: barbkess
-ms.date: 11/24/2020
+ms.date: 07/04/2022
 ms.topic: include
 ms.custom: devx-track-azurecli
 ---
 
 ## Overview
 
-For Linux distributions with `dnf` such as RHEL, Fedora, or CentOS, there's a package
-for the Azure CLI. This package has been tested with RHEL 7.7, RHEL 8, Fedora 24 and higher, CentOS 7 and CentOS Stream 8.
+For Linux distributions with `dnf` such as RHEL 8 or CentOS Stream 8, there are RPM packages for Azure CLI.
+
+> [!WARNING]
+> Starting from Azure CLI 2.39.0 (released on 08/02/2022), no RPM packages will be released for RHEL 7 and CentOS 7. You may continue to use historical versions of Azure CLI on these systems, but there will be no updates or bugfixes. Consider upgrading to newer versions of RHEL or CentOS to use the latest Azure CLI.
 
 [!INCLUDE [current-version](current-version.md)]
 


### PR DESCRIPTION
Add warning for dropping RHEL 7 and CentOS 7 RPMs (https://github.com/Azure/azure-cli/pull/23047).