### PR TITLE
Add hyperlink to *Install script*

### DIFF
--- a/docs-ref-conceptual/install-azure-cli-linux.md
+++ b/docs-ref-conceptual/install-azure-cli-linux.md
@@ -17,7 +17,7 @@ keywords: linux cli, azure cli linux, install azure cli ubuntu, install azure cl
 # Install the Azure CLI on Linux
 
 The Azure CLI is a cross-platform command-line tool that can be installed locally on Linux computers. You can use the Azure CLI on Linux to connect to Azure and execute administrative commands on Azure resources. The CLI on Linux allows the execution of various commands through a terminal using interactive command-line prompts or a script.
-When you are ready to install the Azure CLI on Linux, it is recommended to use a Linux distribution's package manager. Select the appropriate package manager for your distribution from the options above.  If you do not have one of the listed package managers, you may manually install the Azure CLI on Linux by selecting the *Install script* option.
+When you are ready to install the Azure CLI on Linux, it is recommended to use a Linux distribution's package manager. Select the appropriate package manager for your distribution from the options above.  If you do not have one of the listed package managers, you may manually install the Azure CLI on Linux by selecting the [Install script](?pivots=script) option.
 
 [!INCLUDE [current-version](includes/current-version.md)]
 


### PR DESCRIPTION
https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt

![image](https://user-images.githubusercontent.com/4003950/177241143-9cce28a3-0524-4ed8-9ce0-e5fbe9e78c72.png)

Customers may be confused by the *Install script* option (https://github.com/MicrosoftDocs/azure-docs-cli/issues/3183) and think it refers to https://aka.ms/InstallAzureCLIDeb

This PR adds hyperlink to solve the confusion.