### PR TITLE
Remove Fedora support for now

### DIFF
--- a/docs-ref-conceptual/install-azure-cli.md
+++ b/docs-ref-conceptual/install-azure-cli.md
@@ -7,7 +7,7 @@ manager: yonzhan
 ms.date: 08/01/2021
 ms.topic: conceptual
 ms.service: azure-cli
-ms.tool: azure-cli 
+ms.tool: azure-cli
 ms.custom: devx-track-azurecli, seo-azure-cli
 keywords: azure cli, install azure cli, azure cli download, download azure cli
 ---
@@ -24,7 +24,7 @@ The Azure CLI is available to install in Windows, macOS and Linux environments. 
 * [Install on macOS](install-azure-cli-macos.md)
 * Install on Linux or Windows Subsystem for Linux (WSL) ([What is WSL?](/windows/wsl/about))
   * [Install with apt on Debian or Ubuntu](./install-azure-cli-linux.md?pivots=apt)
-  * [Install with dnf on RHEL, Fedora, or CentOS](./install-azure-cli-linux.md?pivots=dnf)
+  * [Install with dnf on RHEL, CentOS](./install-azure-cli-linux.md?pivots=dnf)
   * [Install with zypper on openSUSE or SLE](./install-azure-cli-linux.md?pivots=zypper)
   * [Install from script](./install-azure-cli-linux.md?pivots=script)
 * [Run in Docker container](run-azure-cli-docker.md)

--- a/docs-ref-conceptual/zone-pivot-groups.yml
+++ b/docs-ref-conceptual/zone-pivot-groups.yml
@@ -7,7 +7,7 @@ groups:
     - id: apt
       title: apt (Ubuntu, Debian)
     - id: dnf
-      title: dnf (RHEL, Fedora, CentOS)
+      title: dnf (RHEL, CentOS)
     - id: tdnf
       title: tdnf (Mariner)
     - id: zypper


### PR DESCRIPTION
With the deprecation of RHEL 7 and Cent OS 7 RPMs package and support for RHEL 8/9 RPMs, Fedora is no longer tested.

Even though we are working on supporting it, it's better to remove it for now.
