### PR TITLE
Update --match-values summary

### DIFF
--- a/latest/docs-ref-autogen/afd/rule.yml
+++ b/latest/docs-ref-autogen/afd/rule.yml
@@ -123,7 +123,7 @@ directCommands:
     summary: Indicate whether rules engine should continue to run the remaining rules or stop if matched. Defaults to Continue.
     description: ''
   - name: --match-values
-    summary: Match values of the match condition.
+    summary: Match values of the match condition. Should be a space separated string of values.
     description: ''
   - name: --match-variable
     parameterValueGroup: ClientPort, Cookies, HostName, HttpVersion, IsDevice, PostArgs, QueryString, RemoteAddress, RequestBody, RequestHeader, RequestMethod, RequestScheme, RequestUri, ServerPort, SocketAddr, SslProtocol, UrlFileExtension, UrlFileName, UrlPath


### PR DESCRIPTION
I discovered recently quite a bit of pain trying to get a bunch of redirect rules created via CLI (because there was A LOT!) that the documentation that I could find on using the azd afd cli for this was comprehensive on what each tag is and can do but not necessarily great on examples for all the types of use cases.

I did find that passing a comma separated array to the --match-values did not yield the result I expected which made no sense to me at first till I found this GitHub issue: https://github.com/Azure/azure-cli/issues/21386

With this being the proposed solution that works:
https://github.com/Azure/azure-cli/issues/21386#issuecomment-1092397230

I decided to amend the documentation just to notify users up front before they spend hours making shell scripts and massaging data into a format when migrating that this would be the proposed format to present the values in.