### PR TITLE
Improve Linux installation instructions: arch

### DIFF
--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -61,7 +61,7 @@ If you prefer a step-by-step installation process, complete the following steps 
 
     ```bash
     AZ_REPO=$(lsb_release -cs)
-    echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" |
+    echo "deb [arch=$(dpkg --print-architecture)] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" |
         sudo tee /etc/apt/sources.list.d/azure-cli.list
     ```
 


### PR DESCRIPTION
Use `dpkg --print-architecture` to get the current architecture instead of hardcoded 'amd64'.