### PR TITLE
Improve Linux installation instructions: apt

### DIFF
--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -52,16 +52,18 @@ If you prefer a step-by-step installation process, complete the following steps 
 2. Download and install the Microsoft signing key:
 
     ```bash
+    sudo mkdir -p /etc/apt/keyrings
     curl -sL https://packages.microsoft.com/keys/microsoft.asc |
         gpg --dearmor |
-        sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
+        sudo tee /etc/apt/keyrings/microsoft.gpg > /dev/null
+    sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
     ```
 
 3. <div id="set-release"/>Add the Azure CLI software repository:
 
     ```bash
     AZ_REPO=$(lsb_release -cs)
-    echo "deb [arch=`dpkg --print-architecture`] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" |
+    echo "deb [arch=`dpkg --print-architecture` signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" |
         sudo tee /etc/apt/sources.list.d/azure-cli.list
     ```
 


### PR DESCRIPTION
New APT security model allows public keys to be connected only to specific repositories. This eliminates the problem that any key could be used in conjunction with any repository, not just the one which distributed its key.

"[..] The key MUST NOT be placed in /etc/apt/trusted.gpg.d or loaded by apt-key add. If future updates to the key will be managed by an apt/dpkg package as recommended below, then it SHOULD be downloaded into /usr/share/keyrings using the same filename that will be provided by the package. If it will be managed locally , it SHOULD be downloaded into /etc/apt/keyrings instead."

[OpenPGP Key Distribution](https://wiki.debian.org/DebianRepository/UseThirdParty#OpenPGP_Key_distribution)

https://manpages.debian.org/bullseye/apt/sources.list.5.en.html https://wiki.debian.org/DebianRepository/UseThirdParty