### PR TITLE
Add devlang in global metadata

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -150,6 +150,7 @@
       "author": "rloutlaw",
       "ms.author": "routlaw",
       "ms.topic": "reference",
+      "devlang": "azurecli",
       "ms.devlang": "azurecli",
       "ms.date": "05/23/2018",
       "showPowerShellPicker": "true",


### PR DESCRIPTION
This PR is to support the reference doc template after removing ms.devlang dependency, work item: https://dev.azure.com/ceapex/Engineering/_workitems/edit/699446