### PR TITLE
fix publicIPAddress typos

### DIFF
--- a/docs-ref-conceptual/azure-cli-vm-tutorial.yml
+++ b/docs-ref-conceptual/azure-cli-vm-tutorial.yml
@@ -160,7 +160,7 @@ items:
 
         ```azurecli-interactive
         az network nic show --ids $NIC_ID \
-          --query '{IP:ipConfigurations[].publicIpAddress.id, Subnet:ipConfigurations[].subnet.id}' \
+          --query '{IP:ipConfigurations[].publicIPAddress.id, Subnet:ipConfigurations[].subnet.id}' \
           -o json
         ```
 
@@ -185,7 +185,7 @@ items:
         ```azurecli-interactive
         read -d '' IP_ID SUBNET_ID <<< $(az network nic show \
           --ids $NIC_ID \
-          --query '[ipConfigurations[].publicIpAddress.id, ipConfigurations[].subnet.id]' \
+          --query '[ipConfigurations[].publicIPAddress.id, ipConfigurations[].subnet.id]' \
           -o tsv)
         ```
 
@@ -217,7 +217,7 @@ items:
           --image UbuntuLTS \
           --generate-ssh-keys \
           --subnet $SUBNET_ID \
-          --query publicIpAddress \
+          --query publicIPAddress \
           -o tsv)
         ```
 


### PR DESCRIPTION
In running through this tutorial, I found an error in a few places where the `publicIPAddress` node in the json was incorrectly referenced as `publicIpAddress`, and I could not continue the steps until fixing the typo.

|incorrect|correct|
|--|--|
|`publicIpAddress`|`publicIPAddress`|

I fixed these typos in this file, and the tutorial works as expected.