### PR TITLE
fixing build validation errors for broken links

### DIFF
--- a/docs-ref-conceptual/azure-cli-configuration.md
+++ b/docs-ref-conceptual/azure-cli-configuration.md
@@ -112,7 +112,7 @@ When you provide a default value, that argument is no longer required by any com
 | | vm | string | The default VM name to use for `az vm` commands. |
 | | vmss | string | The default virtual machine scale set (VMSS) name to use for `az vmss` commands. |
 | | acr | string | The default container registry name to use for `az acr` commands. |
-| __storage__ | account | string | The default storage account name (e.g., **mystorageaccount** in https://mystorageaccount.blob.core.windows.net) to use for `az storage` data-plane commands (e.g., `az storage container list`). |
+| __storage__ | account | string | The default storage account name (e.g., **mystorageaccount** in `https://mystorageaccount.blob.core.windows.net`) to use for `az storage` data-plane commands (e.g., `az storage container list`). |
 | | key | string | The default access key to use for `az storage` data-plane commands. |
 | | sas\_token | string | The default SAS token to use for `az storage` data-plane commands. |
 | | connection\_string | string | The default connection string to use for `az storage` data-plane commands. |

--- a/docs-ref-conceptual/azure-cli-configuration.md
+++ b/docs-ref-conceptual/azure-cli-configuration.md
@@ -4,7 +4,7 @@ description: The Azure CLI allows user configuration for various settings. Manag
 author: dbradish-microsoft
 ms.author: dbradish
 manager: barbkess
-ms.date: 06/19/2023 
+ms.date: 07/13/2023 
 ms.topic: conceptual
 ms.service: azure-cli
 ms.tool: azure-cli
@@ -100,7 +100,7 @@ When you provide a default value, that argument is no longer required by any com
 |---------|-----------|------|------------|
 | __core__ | output | string | The default output format. Can be one of `json`, `jsonc`, `tsv`, or `table`. |
 | | disable\_confirm\_prompt | boolean | Turn confirmation prompts on/off. |
-| | display\_region\_identified | boolean | Azure customers can choose to deploy resources in many different regions.  In some cases, customers may be able to reduce costs by selecting nearby regions offering the same services.  If a nearby region is identified, a message will display the region to select for future deployments. |This setting controls if the message will be displayed.
+| | display\_region\_identified | boolean | Azure customers can choose to deploy resources in many different regions.  In some cases, customers may be able to reduce costs by selecting nearby regions offering the same services.  If a nearby region is identified, a message will display the region to select for future deployments. This setting controls if the message will be displayed.
 | | collect\_telemetry | boolean | Allow Microsoft to collect anonymous data on the usage of the CLI. For privacy information, see the [Azure CLI MIT license](https://github.com/Azure/azure-cli/blob/dev/LICENSE). |
 | | only\_show\_errors | boolean | Only show errors during command invocation. In other words, only errors will be written to `stderr`. It suppresses warnings from preview, deprecated and experimental commands. It is also available for individual commands with the `--only-show-errors` parameter. |
 | | no\_color | boolean | Disable color. Originally colored messages will be prefixed with `DEBUG`, `INFO`, `WARNING` and `ERROR`. This bypasses the issue of a third-party library where the terminal's color cannot revert back after a `stdout` redirection. |

--- a/docs-ref-conceptual/azure-cli-endpoints.md
+++ b/docs-ref-conceptual/azure-cli-endpoints.md
@@ -25,9 +25,9 @@ The following tables provide lists of the endpoints and suffixes used by the Azu
 
 |Endpoint group | Endpoint
 |-|-|
-management | https://management.core.windows.net/
-resource_manager | https://management.azure.com/
-sql_management | https://management.core.windows.net:8443/
+management | `https://management.core.windows.net/`
+resource_manager | _https://management.azure.com/_
+sql_management | \https://management.core.windows.net:8443/
 batch_resource_id | https://batch.core.windows.net/
 gallery | https://gallery.azure.com/
 active_directory | https://login.microsoftonline.com

--- a/docs-ref-conceptual/azure-cli-endpoints.md
+++ b/docs-ref-conceptual/azure-cli-endpoints.md
@@ -67,23 +67,23 @@ attestation_endpoint | *.attest.azure.net
 
 |Endpoint group | Endpoint
 |-|-|
-management | https://management.core.usgovcloudapi.net/
-resource_manager | https://management.usgovcloudapi.net/
-sql_management | https://management.core.usgovcloudapi.net:8443/
-batch_resource_id | https://batch.core.usgovcloudapi.net/
-gallery | https://gallery.usgovcloudapi.net/
-active_directory | https://login.microsoftonline.us
-active_directory_resource_id | https://management.core.usgovcloudapi.net/
-active_directory_graph_resource_id | https://graph.windows.net/
-microsoft_graph_resource_id | https://graph.microsoft.us/
-vm_image_alias_doc | https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/rm-compute/quickstart-templates/aliases.json
-media_resource_id | https://rest.media.usgovcloudapi.net
-ossrdbms_resource_id | https://ossrdbms-aad.database.usgovcloudapi.net
-app_insights_resource_id | https://api.applicationinsights.us
-log_analytics_resource_id | https://api.loganalytics.us
-app_insights_telemetry_channel_resource_id | https://dc.applicationinsights.us/v2/track
-synapse_analytics_resource_id | https://dev.azuresynapse.usgovcloudapi.net
-portal | https://portal.azure.us
+management | `https://management.core.usgovcloudapi.net/`
+resource_manager | `https://management.usgovcloudapi.net/`
+sql_management | `https://management.core.usgovcloudapi.net:8443/`
+batch_resource_id | `https://batch.core.usgovcloudapi.net/`
+gallery | `https://gallery.usgovcloudapi.net/`
+active_directory | `https://login.microsoftonline.us`
+active_directory_resource_id | `https://management.core.usgovcloudapi.net/`
+active_directory_graph_resource_id | `https://graph.windows.net/`
+microsoft_graph_resource_id | `https://graph.microsoft.us/`
+vm_image_alias_doc | `https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/rm-compute/quickstart-templates/aliases.json`
+media_resource_id | `https://rest.media.usgovcloudapi.net`
+ossrdbms_resource_id | `https://ossrdbms-aad.database.usgovcloudapi.net`
+app_insights_resource_id | `https://api.applicationinsights.us`
+log_analytics_resource_id | `https://api.loganalytics.us`
+app_insights_telemetry_channel_resource_id | `https://dc.applicationinsights.us/v2/track`
+synapse_analytics_resource_id | `https://dev.azuresynapse.usgovcloudapi.net`
+portal | `https://portal.azure.us`
 
 ### Endpoint suffixes
 
@@ -104,23 +104,23 @@ synapse_analytics_endpoint | *.dev.azuresynapse.usgovcloudapi.net'
 
 |Endpoint group | Endpoint
 |-|-|
-management | https://management.core.chinacloudapi.cn/
-resource_manager | https://management.chinacloudapi.cn
-sql_management | https://management.core.chinacloudapi.cn:8443/
-batch_resource_id | https://batch.chinacloudapi.cn/
-gallery | https://gallery.chinacloudapi.cn/
-active_directory | https://login.chinacloudapi.cn
-active_directory_resource_id | https://management.core.chinacloudapi.cn/
-active_directory_graph_resource_id | https://graph.chinacloudapi.cn/
-microsoft_graph_resource_id | https://microsoftgraph.chinacloudapi.cn
-vm_image_alias_doc | https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/rm-compute/quickstart-templates/aliases.json
-media_resource_id | https://rest.media.chinacloudapi.cn
-ossrdbms_resource_id | https://ossrdbms-aad.database.chinacloudapi.cn
-app_insights_resource_id | https://api.applicationinsights.azure.cn
-log_analytics_resource_id | https://api.loganalytics.azure.cn
-app_insights_telemetry_channel_resource_id | https://dc.applicationinsights.azure.cn/v2/rack
-synapse_analytics_resource_id | https://dev.azuresynapse.azure.cn
-portal | https://portal.azure.cn
+management | `https://management.core.chinacloudapi.cn/`
+resource_manager | `https://management.chinacloudapi.cn`
+sql_management | `https://management.core.chinacloudapi.cn:8443/`
+batch_resource_id | `https://batch.chinacloudapi.cn/`
+gallery | `https://gallery.chinacloudapi.cn/`
+active_directory | `https://login.chinacloudapi.cn`
+active_directory_resource_id | `https://management.core.chinacloudapi.cn/`
+active_directory_graph_resource_id | `https://graph.chinacloudapi.cn/`
+microsoft_graph_resource_id | `https://microsoftgraph.chinacloudapi.cn`
+vm_image_alias_doc | `https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/rm-compute/quickstart-templates/aliases.json`
+media_resource_id | `https://rest.media.chinacloudapi.cn`
+ossrdbms_resource_id | `https://ossrdbms-aad.database.chinacloudapi.cn`
+app_insights_resource_id | `https://api.applicationinsights.azure.cn`
+log_analytics_resource_id | `https://api.loganalytics.azure.cn`
+app_insights_telemetry_channel_resource_id | `https://dc.applicationinsights.azure.cn/v2/rack`
+synapse_analytics_resource_id | `https://dev.azuresynapse.azure.cn`
+portal | `https://portal.azure.cn`
 
 ### Endpoint suffixes
 
@@ -140,7 +140,7 @@ synapse_analytics_endpoint | *.dev.azuresynapse.azure.cn
 
 ## Extensions
 
-Azure CLI extensions are optional and installed separately.  The Azure CLI uses https://aka.ms/azure-cli-extension-index-v1 to fetch a list of extensions.  This _aka.ms_ link points to https://github.com/Azure/azure-cli/blob/3feea02888ea67f033f407174a3a7a340158b81a/src/azure-cli-core/azure/cli/core/extension/_index.py#L11.  
+Azure CLI extensions are optional and installed separately.  The Azure CLI uses `https://aka.ms/azure-cli-extension-index-v1 to fetch a list of extensions.  This _aka.ms_ link points to `https://github.com/Azure/azure-cli/blob/3feea02888ea67f033f407174a3a7a340158b81a/src/azure-cli-core/azure/cli/core/extension/_index.py#L11.  
 
 All extensions install with endpoint **azcliprod.blob.core.windows.net** with the following exceptions:
 

--- a/docs-ref-conceptual/azure-cli-endpoints.md
+++ b/docs-ref-conceptual/azure-cli-endpoints.md
@@ -25,25 +25,25 @@ The following tables provide lists of the endpoints and suffixes used by the Azu
 
 |Endpoint group | Endpoint
 |-|-|
-management | _https://management.core.windows.net/_
-resource_manager | _https://management.azure.com/_
-sql_management | _https://management.core.windows.net:8443/_
-batch_resource_id | _https://batch.core.windows.net/_
-gallery | _https://gallery.azure.com/_
-active_directory | _https://login.microsoftonline.com_
-active_directory_resource_id | _https://management.core.windows.net/_
-active_directory_graph_resource_id | _https://graph.windows.net/_
-microsoft_graph_resource_id | _https://graph.microsoft.com/_
-active_directory_data_lake_resource_id | _https://datalake.azure.net/_
-vm_image_alias_doc | _https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/arm-compute/quickstart-templates/aliases.json_
-media_resource_id | _https://rest.media.azure.net_
-ossrdbms_resource_id | _https://ossrdbms-aad.database.windows.net_
-app_insights_resource_id | _https://api.applicationinsights.io_
-log_analytics_resource_id | _https://api.loganalytics.io_
-app_insights_telemetry_channel_resource_id | _https://dc.applicationinsights.azure.com/v2/track_
-synapse_analytics_resource_id | _https://dev.azuresynapse.net_
-attestation_resource_id | _https://attest.azure.net_
-portal | _https://portal.azure.com_
+management | `https://management.core.windows.net/`
+resource_manager | `https://management.azure.com/`
+sql_management | `https://management.core.windows.net:8443/`
+batch_resource_id | `https://batch.core.windows.net/`
+gallery | `https://gallery.azure.com/`
+active_directory | `https://login.microsoftonline.com_`
+active_directory_resource_id | `https://management.core.windows.net/`
+active_directory_graph_resource_id | `https://graph.windows.net/`
+microsoft_graph_resource_id | `https://graph.microsoft.com/`
+active_directory_data_lake_resource_id | `https://datalake.azure.net/`
+vm_image_alias_doc | `https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/arm-compute/quickstart-templates/aliases.json_`
+media_resource_id | `https://rest.media.azure.net_`
+ossrdbms_resource_id | `https://ossrdbms-aad.database.windows.net_`
+app_insights_resource_id | `https://api.applicationinsights.io_`
+log_analytics_resource_id | `https://api.loganalytics.io_`
+app_insights_telemetry_channel_resource_id | `https://dc.applicationinsights.azure.com/v2/track_`
+synapse_analytics_resource_id | `https://dev.azuresynapse.net_`
+attestation_resource_id | `https://attest.azure.net_`
+portal | `https://portal.azure.com_`
 
 ### Endpoint suffixes
 

--- a/docs-ref-conceptual/azure-cli-endpoints.md
+++ b/docs-ref-conceptual/azure-cli-endpoints.md
@@ -7,7 +7,7 @@ ms.author: dbradish
 ms.prod: non-product-specific
 ms.topic: conceptual
 ms.custom: devx-track-azurecli
-ms.date: 11/14/2022
+ms.date: 07/13/2023
 ms.tool: azure-cli
 ---
 

--- a/docs-ref-conceptual/azure-cli-endpoints.md
+++ b/docs-ref-conceptual/azure-cli-endpoints.md
@@ -25,25 +25,25 @@ The following tables provide lists of the endpoints and suffixes used by the Azu
 
 |Endpoint group | Endpoint
 |-|-|
-management | `https://management.core.windows.net/`
+management | _https://management.core.windows.net/_
 resource_manager | _https://management.azure.com/_
-sql_management | \https://management.core.windows.net:8443/
-batch_resource_id | https://batch.core.windows.net/
-gallery | https://gallery.azure.com/
-active_directory | https://login.microsoftonline.com
-active_directory_resource_id | https://management.core.windows.net/
-active_directory_graph_resource_id | https://graph.windows.net/
-microsoft_graph_resource_id | https://graph.microsoft.com/
-active_directory_data_lake_resource_id | https://datalake.azure.net/
-vm_image_alias_doc | https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/arm-compute/quickstart-templates/aliases.json
-media_resource_id | https://rest.media.azure.net
-ossrdbms_resource_id | https://ossrdbms-aad.database.windows.net
-app_insights_resource_id | https://api.applicationinsights.io
-log_analytics_resource_id | https://api.loganalytics.io
-app_insights_telemetry_channel_resource_id | https://dc.applicationinsights.azure.com/v2/track
-synapse_analytics_resource_id | https://dev.azuresynapse.net
-attestation_resource_id | https://attest.azure.net
-portal | https://portal.azure.com
+sql_management | _https://management.core.windows.net:8443/_
+batch_resource_id | _https://batch.core.windows.net/_
+gallery | _https://gallery.azure.com/_
+active_directory | _https://login.microsoftonline.com_
+active_directory_resource_id | _https://management.core.windows.net/_
+active_directory_graph_resource_id | _https://graph.windows.net/_
+microsoft_graph_resource_id | _https://graph.microsoft.com/_
+active_directory_data_lake_resource_id | _https://datalake.azure.net/_
+vm_image_alias_doc | _https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/arm-compute/quickstart-templates/aliases.json_
+media_resource_id | _https://rest.media.azure.net_
+ossrdbms_resource_id | _https://ossrdbms-aad.database.windows.net_
+app_insights_resource_id | _https://api.applicationinsights.io_
+log_analytics_resource_id | _https://api.loganalytics.io_
+app_insights_telemetry_channel_resource_id | _https://dc.applicationinsights.azure.com/v2/track_
+synapse_analytics_resource_id | _https://dev.azuresynapse.net_
+attestation_resource_id | _https://attest.azure.net_
+portal | _https://portal.azure.com_
 
 ### Endpoint suffixes
 

--- a/docs-ref-conceptual/azure-cli-endpoints.md
+++ b/docs-ref-conceptual/azure-cli-endpoints.md
@@ -140,7 +140,7 @@ synapse_analytics_endpoint | *.dev.azuresynapse.azure.cn
 
 ## Extensions
 
-Azure CLI extensions are optional and installed separately.  The Azure CLI uses `https://aka.ms/azure-cli-extension-index-v1 to fetch a list of extensions.  This _aka.ms_ link points to `https://github.com/Azure/azure-cli/blob/3feea02888ea67f033f407174a3a7a340158b81a/src/azure-cli-core/azure/cli/core/extension/_index.py#L11.  
+Azure CLI extensions are optional and installed separately.  The Azure CLI uses https://aka.ms/azure-cli-extension-index-v1 to fetch a list of extensions.  This _aka.ms_ link points to https://github.com/Azure/azure-cli/blob/3feea02888ea67f033f407174a3a7a340158b81a/src/azure-cli-core/azure/cli/core/extension/_index.py#L11.  
 
 All extensions install with endpoint **azcliprod.blob.core.windows.net** with the following exceptions:
 

--- a/docs-ref-conceptual/azure-cli-support-request.md
+++ b/docs-ref-conceptual/azure-cli-support-request.md
@@ -101,5 +101,5 @@ az support tickets communications list --ticket-name VM012 \
 ## Next steps
 
 - [Azure Support FAQs](https://azure.microsoft.com/support/faq/)
-- [Azure severity and levels](https://azure.microsoft.com/support/plans/response/)
+- [Azure support scope and responsiveness](https://azure.microsoft.com/support/plans/response/)
 - [How to create a support ticket via Azure portal](/azure/azure-portal/supportability/how-to-create-azure-support-request)

--- a/docs-ref-conceptual/azure-cli-support-request.md
+++ b/docs-ref-conceptual/azure-cli-support-request.md
@@ -6,7 +6,7 @@ author: dbradish-microsoft
 ms.author: dbradish
 ms.service: azure-supportability
 ms.topic: how-to
-ms.date: 06/19/2023
+ms.date: 07/13/2023
 ms.tool: azure-cli
 ms.custom: template-how-to, devx-track-azurecli, seo-azure-cli
 keywords: azure support request, azure support, azure support ticket, support ticket management
@@ -54,7 +54,7 @@ To create a support request, you must be an [Owner](/azure/role-based-access-con
       --contact-country US --contact-language English --contact-timezone "Pacific Standard Time"
    ```
 
-A support engineer will contact you using the method you indicated. For information about initial response times, see [Support scope and responsiveness](/support/plans/response/).
+A support engineer will contact you using the method you indicated. For information about initial response times, see [Support scope and responsiveness](https://azure.microsoft.com/support/plans/response/).
 
 ## Manage support tickets
 

--- a/docs-ref-conceptual/azure-cli-vm-tutorial-7.md
+++ b/docs-ref-conceptual/azure-cli-vm-tutorial-7.md
@@ -1,7 +1,7 @@
 ---
 title: Summary of virtual machine resources (VM) – Azure CLI | Microsoft Docs
 description: Summary of what was taught in the virtual machine tutorial.
-ms.date: 06/19/2023
+ms.date: 07/13/2023
 manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish

--- a/docs-ref-conceptual/azure-cli-vm-tutorial-7.md
+++ b/docs-ref-conceptual/azure-cli-vm-tutorial-7.md
@@ -24,9 +24,10 @@ in depth on the features covered in this tutorial.
 
 If you want to get started right away with specific tasks, look at some sample scripts.
 
+* [A - Z list of Azure CLI samples](samples-index.md)
 * Working with [Linux VMs](/azure/virtual-machines/linux/cli-samples?toc=%2fcli%2fazure%2ftoc.json) and [Windows VMs](/azure/virtual-machines/windowcli-samples?toc=%2fcli%2fazure%2ftoc.json)
-* Working with [webapps](/azure/app-service/app-service-cli-samples?toc=%2Fcli%2Fazure%2Ftoc.json) and [Azure Functions](/azure/azure-functionfunctions-cli-samples?toc=%2fcli%2fazure%2ftoc.json)
-* Working with databases - [Azure SQL databases](/azure/sql-database/sql-database-cli-samples?toc=%2fcli%2fazure%2ftoc.json), [PostgreSQL](/azurpostgresql/sample-scripts-azure-cli?toc=%2fcli%2fazure%2ftoc.json), [MySQL](/azure/mysql/sample-scripts-azure-cli?toc=%2fcli%2fazure%2ftoc.json), an[CosmosDB](/azure/cosmos-db/cli-samples?toc=%2fcli%2fazure%2ftoc.json).
+* Working with [webapps](/azure/app-service/samples-cli?toc=%2Fcli%2Fazure%2Ftoc.json) and [Azure Functions](/azure/azure-functions/functions-cli-samples?toc=%2fcli%2fazure%2ftoc.json)
+* Working with databases - [Azure SQL databases](/azure/sql-database/sql-database-cli-samples?toc=%2fcli%2fazure%2ftoc.json), [PostgreSQL](/azure/postgresql/single-server/sample-scripts-azure-cli?toc=%2fcli%2fazure%2ftoc.json), [MySQL](/azure/mysql/flexible-server/sample-scripts-azure-cli?toc=%2fcli%2fazure%2ftoc.json), an[CosmosDB](/azure/cosmos-db/nosql/cli-samples?toc=%2fcli%2fazure%2ftoc.json).
 
 ## Get support
 

--- a/docs-ref-conceptual/azure-cli-vm-tutorial-7.md
+++ b/docs-ref-conceptual/azure-cli-vm-tutorial-7.md
@@ -25,9 +25,7 @@ in depth on the features covered in this tutorial.
 If you want to get started right away with specific tasks, look at some sample scripts.
 
 * [A - Z list of Azure CLI samples](samples-index.md)
-* Working with [Linux VMs](/azure/virtual-machines/linux/cli-samples?toc=%2fcli%2fazure%2ftoc.json) and [Windows VMs](/azure/virtual-machines/windowcli-samples?toc=%2fcli%2fazure%2ftoc.json)
-* Working with [webapps](/azure/app-service/samples-cli?toc=%2Fcli%2Fazure%2Ftoc.json) and [Azure Functions](/azure/azure-functions/functions-cli-samples?toc=%2fcli%2fazure%2ftoc.json)
-* Working with databases - [Azure SQL databases](/azure/sql-database/sql-database-cli-samples?toc=%2fcli%2fazure%2ftoc.json), [PostgreSQL](/azure/postgresql/single-server/sample-scripts-azure-cli?toc=%2fcli%2fazure%2ftoc.json), [MySQL](/azure/mysql/flexible-server/sample-scripts-azure-cli?toc=%2fcli%2fazure%2ftoc.json), an[CosmosDB](/azure/cosmos-db/nosql/cli-samples?toc=%2fcli%2fazure%2ftoc.json).
+* [Azure CLI samples GitHub repository - VMs](https://github.com/Azure-Samples/azure-cli-samples/tree/master/virtual-machine)
 
 ## Get support
 

--- a/docs-ref-conceptual/param-persist-tutorial.md
+++ b/docs-ref-conceptual/param-persist-tutorial.md
@@ -256,7 +256,7 @@ az functionapp create \
 
 ## 6. Delete persisted parameters
 
-Use the [az config param-persist delete](/cli/azure/param-persist#az_param_persist_delete) command to remove entries.
+Use the [az config param-persist delete](/cli/azure/config/param-persist#az-config-param-persist-delete) command to remove entries.
 
 ```azurecli
 # Remove a single persisted parameters entry by specifying the name, not the value
@@ -283,7 +283,7 @@ az config param-persist delete --all --yes
 
 ## 7. Turn persisted parameters off
 
-You can turn persisted parameters off by using the [az config param-persist off](/cli/azure/param-persist#az_param_persist_off) command, but your saved persisted parameters data won't be deleted.
+You can turn persisted parameters off by using the [az config param-persist off](/cli/azure/config/param-persist#az-config-param-persist-off) command, but your saved persisted parameters data won't be deleted.
 
 ```azurecli
 # Turn persisted parameters off

--- a/docs-ref-conceptual/param-persist-tutorial.md
+++ b/docs-ref-conceptual/param-persist-tutorial.md
@@ -5,7 +5,7 @@ manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.service: azure-cli
-ms.date: 06/19/2023
+ms.date: 07/13/2023
 ms.topic: tutorial
 ms.tool: azure-cli
 ms.custom: devx-track-azurecli, seo-azure-cli


### PR DESCRIPTION
`Backticks` have been used to stop build validation errors for HTTP addresses that will not work independently by design.  For consistency, all http addresses have been formatted this way, even if the address was valid.

**Example error:** _Link 'https://batch.core.windows.net/' points to a page that doesn't exist. Check the path or URL and update the link._
**Example fix:** `https://batch.core.windows.net/`