### PR TITLE
moved tab completion to /include file

### DIFF
--- a/docs-ref-conceptual/includes/specific-version.md
+++ b/docs-ref-conceptual/includes/specific-version.md
@@ -2,12 +2,12 @@
 author: dbradish-microsoft
 ms.author: dbradish
 manager: barbkess
-ms.date: 08/08/2023
+ms.date: 09/13/2023
 ms.topic: include
 ms.custom: devx-track-azurecli
 ---
 To download the MSI installer for a specific version, change the version segment in URL `https://azcliprod.blob.core.windows.net/msi/azure-cli-<version>.msi` (32-bit) or `https://azcliprod.blob.core.windows.net/msi/azure-cli-<version>-x64.msi` (64-bit).
 
-For example, to install the 32-bit MSI of Azure CLI version [2.51.0](/cli/azure/release-notes-azure-cli#august-01-2023), your URL would be `https://azcliprod.blob.core.windows.net/msi/azure-cli-2.51.0.msi`.  The corresponding 64-bit install would be `https://azcliprod.blob.core.windows.net/msi/azure-cli-2.51.0-x64.msi`.
+For example, to install the 32-bit MSI of Azure CLI version [2.51.0](/cli/azure/release-notes-azure-cli#august-01-2023), your URL would be `https://azcliprod.blob.core.windows.net/msi/azure-cli-2.51.0.msi`. The corresponding 64-bit install would be `https://azcliprod.blob.core.windows.net/msi/azure-cli-2.51.0-x64.msi`.
 
 Available Azure CLI versions can be found at [Azure CLI release notes](../release-notes-azure-cli.md). The 64-bit MSI is available from version [2.51.0](/cli/azure/release-notes-azure-cli#august-01-2023).

--- a/docs-ref-conceptual/includes/specific-version.md
+++ b/docs-ref-conceptual/includes/specific-version.md
@@ -6,7 +6,7 @@ ms.date: 08/08/2023
 ms.topic: include
 ms.custom: devx-track-azurecli
 ---
-You can download a specific version of the Azure CLI by using a URL and changing the version segment in `https://azcliprod.blob.core.windows.net/msi/azure-cli-<version>.msi` (32-bit) or `https://azcliprod.blob.core.windows.net/msi/azure-cli-<version>-x64.msi` (64-bit).
+To download the MSI installer for a specific version, change the version segment in URL `https://azcliprod.blob.core.windows.net/msi/azure-cli-<version>.msi` (32-bit) or `https://azcliprod.blob.core.windows.net/msi/azure-cli-<version>-x64.msi` (64-bit).
 
 For example, to install the 32-bit MSI of Azure CLI version [2.51.0](/cli/azure/release-notes-azure-cli#august-01-2023), your URL would be `https://azcliprod.blob.core.windows.net/msi/azure-cli-2.51.0.msi`.  The corresponding 64-bit install would be `https://azcliprod.blob.core.windows.net/msi/azure-cli-2.51.0-x64.msi`.
 

--- a/docs-ref-conceptual/includes/specific-version.md
+++ b/docs-ref-conceptual/includes/specific-version.md
@@ -6,7 +6,7 @@ ms.date: 08/08/2023
 ms.topic: include
 ms.custom: devx-track-azurecli
 ---
-To download the MSI installer for a specific version, change the version segment in URL `https://azcliprod.blob.core.windows.net/msi/azure-cli-<version>.msi` (32-bit) or `https://azcliprod.blob.core.windows.net/msi/azure-cli-<version>-x64.msi` (64-bit) and download it.
+You can download a specific version of the Azure CLI by using a URL and changing the version segment in `https://azcliprod.blob.core.windows.net/msi/azure-cli-<version>.msi` (32-bit) or `https://azcliprod.blob.core.windows.net/msi/azure-cli-<version>-x64.msi` (64-bit).
 
 For example, to install the 32-bit MSI of Azure CLI version [2.51.0](/cli/azure/release-notes-azure-cli#august-01-2023), your URL would be `https://azcliprod.blob.core.windows.net/msi/azure-cli-2.51.0.msi`.  The corresponding 64-bit install would be `https://azcliprod.blob.core.windows.net/msi/azure-cli-2.51.0-x64.msi`.
 

--- a/docs-ref-conceptual/includes/tab-completion.md
+++ b/docs-ref-conceptual/includes/tab-completion.md
@@ -5,33 +5,32 @@ ms.date: 08/08/2023
 ms.topic: include
 ms.custom: devx-track-azurecli
 ---
-PowerShell provides completion on inputs to provide hints, enable discovery and speed up input entry. Command names, command group names, parameters and certain parameter values can be completed by pressing the <kbd>Tab</kbd> key.
+Tab completion, also known as "Azure CLI completers", provides completion on inputs to provide hints, enable discovery and speed up input entry. Command names, command group names, parameters and certain parameter values can be automatically inserted into the command line by pressing the <kbd>Tab</kbd> key.
 
-> [!Note]
-> Azure CLI version 2.49 or higher is required to enable tab completion for Azure CLI on PowerShell.
+Tab completion is enabled by default in Azure Cloud Shell and in most Linux distributions. Starting in Azure CLI version 2.49, you can enable tab completion for the Azure CLI in PowerShell. Follow these steps:
 
-To enable tab completion in PowerShell, create or edit the profile stored in the variable `$PROFILE`. The simplest way is to run `notepad $PROFILE` in PowerShell. For more information, see [How to create your profile](/powershell/module/microsoft.powershell.core/about/about_profiles#how-to-create-a-profile) and [Profiles and execution policy](/powershell/module/microsoft.powershell.core/about/about_profiles#profiles-and-execution-policy).
+1. Create or edit the profile stored in the variable `$PROFILE`. The simplest way is to run `notepad $PROFILE` in PowerShell. For more information, see [How to create your profile](/powershell/module/microsoft.powershell.core/about/about_profiles#how-to-create-a-profile) and [Profiles and execution policy](/powershell/module/microsoft.powershell.core/about/about_profiles#profiles-and-execution-policy).
 
-Then add the following code to your PowerShell profile:
+1.  Add the following code to your PowerShell profile:
 
-```powershell
-Register-ArgumentCompleter -Native -CommandName az -ScriptBlock {
-    param($commandName, $wordToComplete, $cursorPosition)
-    $completion_file = New-TemporaryFile
-    $env:ARGCOMPLETE_USE_TEMPFILES = 1
-    $env:_ARGCOMPLETE_STDOUT_FILENAME = $completion_file
-    $env:COMP_LINE = $wordToComplete
-    $env:COMP_POINT = $cursorPosition
-    $env:_ARGCOMPLETE = 1
-    $env:_ARGCOMPLETE_SUPPRESS_SPACE = 0
-    $env:_ARGCOMPLETE_IFS = "`n"
-    $env:_ARGCOMPLETE_SHELL = 'powershell'
-    az 2>&1 | Out-Null
-    Get-Content $completion_file | Sort-Object | ForEach-Object {
-        [System.Management.Automation.CompletionResult]::new($_, $_, "ParameterValue", $_)
-    }
-    Remove-Item $completion_file, Env:\_ARGCOMPLETE_STDOUT_FILENAME, Env:\ARGCOMPLETE_USE_TEMPFILES, Env:\COMP_LINE, Env:\COMP_POINT, Env:\_ARGCOMPLETE, Env:\_ARGCOMPLETE_SUPPRESS_SPACE, Env:\_ARGCOMPLETE_IFS, Env:\_ARGCOMPLETE_SHELL
-}
-```
+   ```powershell
+   Register-ArgumentCompleter -Native -CommandName az -ScriptBlock {
+       param($commandName, $wordToComplete, $cursorPosition)
+       $completion_file = New-TemporaryFile
+       $env:ARGCOMPLETE_USE_TEMPFILES = 1
+       $env:_ARGCOMPLETE_STDOUT_FILENAME = $completion_file
+       $env:COMP_LINE = $wordToComplete
+       $env:COMP_POINT = $cursorPosition
+       $env:_ARGCOMPLETE = 1
+       $env:_ARGCOMPLETE_SUPPRESS_SPACE = 0
+       $env:_ARGCOMPLETE_IFS = "`n"
+       $env:_ARGCOMPLETE_SHELL = 'powershell'
+       az 2>&1 | Out-Null
+       Get-Content $completion_file | Sort-Object | ForEach-Object {
+           [System.Management.Automation.CompletionResult]::new($_, $_, "ParameterValue",    $_)
+       }
+       Remove-Item $completion_file, Env:\_ARGCOMPLETE_STDOUT_FILENAME,    Env:\ARGCOMPLETE_USE_TEMPFILES, Env:\COMP_LINE, Env:\COMP_POINT, Env:\_ARGCOMPLETE,    Env:\_ARGCOMPLETE_SUPPRESS_SPACE, Env:\_ARGCOMPLETE_IFS, Env:\_ARGCOMPLETE_SHELL
+   }
+   ```
 
-To display all available options in the  menu, add `Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete` to your PowerShell profile.
+1. To display all available options in the  menu, add `Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete` to your PowerShell profile.

--- a/docs-ref-conceptual/includes/tab-completion.md
+++ b/docs-ref-conceptual/includes/tab-completion.md
@@ -27,9 +27,9 @@ Tab completion is enabled by default in Azure Cloud Shell and in most Linux dist
           $env:_ARGCOMPLETE_SHELL = 'powershell'
           az 2>&1 | Out-Null
           Get-Content $completion_file | Sort-Object | ForEach-Object {
-              [System.Management.Automation.CompletionResult]::new($_, $_,    "ParameterValue",    $_)
+              [System.Management.Automation.CompletionResult]::new($_, $_, "ParameterValue", $_)
           }
-          Remove-Item $completion_file, Env:\_ARGCOMPLETE_STDOUT_FILENAME,       Env:\ARGCOMPLETE_USE_TEMPFILES, Env:\COMP_LINE, Env:\COMP_POINT,    Env:\_ARGCOMPLETE,    Env:\_ARGCOMPLETE_SUPPRESS_SPACE, Env:\_ARGCOMPLETE_IFS,    Env:\_ARGCOMPLETE_SHELL
+          Remove-Item $completion_file, Env:\_ARGCOMPLETE_STDOUT_FILENAME, Env:\ARGCOMPLETE_USE_TEMPFILES, Env:\COMP_LINE, Env:\COMP_POINT, Env:\_ARGCOMPLETE, Env:\_ARGCOMPLETE_SUPPRESS_SPACE, Env:\_ARGCOMPLETE_IFS, Env:\_ARGCOMPLETE_SHELL
       }
       ```
 1. To display all available options in the menu, add `Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete` to your PowerShell profile.

--- a/docs-ref-conceptual/includes/tab-completion.md
+++ b/docs-ref-conceptual/includes/tab-completion.md
@@ -1,0 +1,37 @@
+---
+author: dbradish-microsoft
+ms.author: dbradish
+ms.date: 08/08/2023
+ms.topic: include
+ms.custom: devx-track-azurecli
+---
+PowerShell provides completion on inputs to provide hints, enable discovery and speed up input entry. Command names, command group names, parameters and certain parameter values can be completed by pressing the <kbd>Tab</kbd> key.
+
+> [!Note]
+> Azure CLI version 2.49 or higher is required to enable tab completion for Azure CLI on PowerShell.
+
+To enable tab completion in PowerShell, create or edit the profile stored in the variable `$PROFILE`. The simplest way is to run `notepad $PROFILE` in PowerShell. For more information, see [How to create your profile](/powershell/module/microsoft.powershell.core/about/about_profiles#how-to-create-a-profile) and [Profiles and execution policy](/powershell/module/microsoft.powershell.core/about/about_profiles#profiles-and-execution-policy).
+
+Then add the following code to your PowerShell profile:
+
+```powershell
+Register-ArgumentCompleter -Native -CommandName az -ScriptBlock {
+    param($commandName, $wordToComplete, $cursorPosition)
+    $completion_file = New-TemporaryFile
+    $env:ARGCOMPLETE_USE_TEMPFILES = 1
+    $env:_ARGCOMPLETE_STDOUT_FILENAME = $completion_file
+    $env:COMP_LINE = $wordToComplete
+    $env:COMP_POINT = $cursorPosition
+    $env:_ARGCOMPLETE = 1
+    $env:_ARGCOMPLETE_SUPPRESS_SPACE = 0
+    $env:_ARGCOMPLETE_IFS = "`n"
+    $env:_ARGCOMPLETE_SHELL = 'powershell'
+    az 2>&1 | Out-Null
+    Get-Content $completion_file | Sort-Object | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new($_, $_, "ParameterValue", $_)
+    }
+    Remove-Item $completion_file, Env:\_ARGCOMPLETE_STDOUT_FILENAME, Env:\ARGCOMPLETE_USE_TEMPFILES, Env:\COMP_LINE, Env:\COMP_POINT, Env:\_ARGCOMPLETE, Env:\_ARGCOMPLETE_SUPPRESS_SPACE, Env:\_ARGCOMPLETE_IFS, Env:\_ARGCOMPLETE_SHELL
+}
+```
+
+To display all available options in the  menu, add `Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete` to your PowerShell profile.

--- a/docs-ref-conceptual/includes/tab-completion.md
+++ b/docs-ref-conceptual/includes/tab-completion.md
@@ -13,24 +13,23 @@ Tab completion is enabled by default in Azure Cloud Shell and in most Linux dist
 
 1.  Add the following code to your PowerShell profile:
 
-   ```powershell
-   Register-ArgumentCompleter -Native -CommandName az -ScriptBlock {
-       param($commandName, $wordToComplete, $cursorPosition)
-       $completion_file = New-TemporaryFile
-       $env:ARGCOMPLETE_USE_TEMPFILES = 1
-       $env:_ARGCOMPLETE_STDOUT_FILENAME = $completion_file
-       $env:COMP_LINE = $wordToComplete
-       $env:COMP_POINT = $cursorPosition
-       $env:_ARGCOMPLETE = 1
-       $env:_ARGCOMPLETE_SUPPRESS_SPACE = 0
-       $env:_ARGCOMPLETE_IFS = "`n"
-       $env:_ARGCOMPLETE_SHELL = 'powershell'
-       az 2>&1 | Out-Null
-       Get-Content $completion_file | Sort-Object | ForEach-Object {
-           [System.Management.Automation.CompletionResult]::new($_, $_, "ParameterValue",    $_)
-       }
-       Remove-Item $completion_file, Env:\_ARGCOMPLETE_STDOUT_FILENAME,    Env:\ARGCOMPLETE_USE_TEMPFILES, Env:\COMP_LINE, Env:\COMP_POINT, Env:\_ARGCOMPLETE,    Env:\_ARGCOMPLETE_SUPPRESS_SPACE, Env:\_ARGCOMPLETE_IFS, Env:\_ARGCOMPLETE_SHELL
-   }
-   ```
-
+      ```powershell
+      Register-ArgumentCompleter -Native -CommandName az -ScriptBlock {
+          param($commandName, $wordToComplete, $cursorPosition)
+          $completion_file = New-TemporaryFile
+          $env:ARGCOMPLETE_USE_TEMPFILES = 1
+          $env:_ARGCOMPLETE_STDOUT_FILENAME = $completion_file
+          $env:COMP_LINE = $wordToComplete
+          $env:COMP_POINT = $cursorPosition
+          $env:_ARGCOMPLETE = 1
+          $env:_ARGCOMPLETE_SUPPRESS_SPACE = 0
+          $env:_ARGCOMPLETE_IFS = "`n"
+          $env:_ARGCOMPLETE_SHELL = 'powershell'
+          az 2>&1 | Out-Null
+          Get-Content $completion_file | Sort-Object | ForEach-Object {
+              [System.Management.Automation.CompletionResult]::new($_, $_,    "ParameterValue",    $_)
+          }
+          Remove-Item $completion_file, Env:\_ARGCOMPLETE_STDOUT_FILENAME,       Env:\ARGCOMPLETE_USE_TEMPFILES, Env:\COMP_LINE, Env:\COMP_POINT,    Env:\_ARGCOMPLETE,    Env:\_ARGCOMPLETE_SUPPRESS_SPACE, Env:\_ARGCOMPLETE_IFS,    Env:\_ARGCOMPLETE_SHELL
+      }
+      ```
 1. To display all available options in the  menu, add `Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete` to your PowerShell profile.

--- a/docs-ref-conceptual/includes/tab-completion.md
+++ b/docs-ref-conceptual/includes/tab-completion.md
@@ -1,7 +1,7 @@
 ---
 author: dbradish-microsoft
 ms.author: dbradish
-ms.date: 08/08/2023
+ms.date: 09/13/2023
 ms.topic: include
 ms.custom: devx-track-azurecli
 ---
@@ -11,7 +11,7 @@ Tab completion is enabled by default in Azure Cloud Shell and in most Linux dist
 
 1. Create or edit the profile stored in the variable `$PROFILE`. The simplest way is to run `notepad $PROFILE` in PowerShell. For more information, see [How to create your profile](/powershell/module/microsoft.powershell.core/about/about_profiles#how-to-create-a-profile) and [Profiles and execution policy](/powershell/module/microsoft.powershell.core/about/about_profiles#profiles-and-execution-policy).
 
-1.  Add the following code to your PowerShell profile:
+1. Add the following code to your PowerShell profile:
 
       ```powershell
       Register-ArgumentCompleter -Native -CommandName az -ScriptBlock {
@@ -32,4 +32,4 @@ Tab completion is enabled by default in Azure Cloud Shell and in most Linux dist
           Remove-Item $completion_file, Env:\_ARGCOMPLETE_STDOUT_FILENAME,       Env:\ARGCOMPLETE_USE_TEMPFILES, Env:\COMP_LINE, Env:\COMP_POINT,    Env:\_ARGCOMPLETE,    Env:\_ARGCOMPLETE_SUPPRESS_SPACE, Env:\_ARGCOMPLETE_IFS,    Env:\_ARGCOMPLETE_SHELL
       }
       ```
-1. To display all available options in the  menu, add `Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete` to your PowerShell profile.
+1. To display all available options in the menu, add `Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete` to your PowerShell profile.

--- a/docs-ref-conceptual/install-azure-cli-windows.md
+++ b/docs-ref-conceptual/install-azure-cli-windows.md
@@ -53,7 +53,7 @@ To install the Azure CLI using PowerShell, start PowerShell **as administrator**
 
 This will download and install the latest 32-bit installer of the Azure CLI for Windows. If you prefer a 64-bit install, change URL to `https://aka.ms/installazurecliwindowsx64`. If the Azure CLI is already installed, the installer will overwrite the existing version.
 
-To install a specific version, replace the `-Uri` argument with the URL described in [Specific version](#specific-version-1).  Here is an example of using the 32-bit installer of the Azure CLI version [2.51.0](/cli/azure/release-notes-azure-cli#august-01-2023) in PowerShell:
+To install a specific version, replace the `-Uri` argument with the URL described in [Specific version](#specific-version).  Here is an example of using the 32-bit installer of the Azure CLI version [2.51.0](/cli/azure/release-notes-azure-cli#august-01-2023) in PowerShell:
 
    ```PowerShell
    $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri https://azcliprod.blob.core.windows.net/msi/azure-cli-2.51.0.msi -OutFile .\AzureCLI.msi; Start-Process msiexec.exe -Wait -ArgumentList '/I AzureCLI.msi /quiet'; Remove-Item .\AzureCLI.msi

--- a/docs-ref-conceptual/install-azure-cli-windows.md
+++ b/docs-ref-conceptual/install-azure-cli-windows.md
@@ -67,10 +67,6 @@ To install a specific version, replace the `-Uri` argument with the URL describe
 
 [!INCLUDE [specific version](includes/specific-version.md)]
 
-### Update the Azure CLI
-
-[!INCLUDE [az upgrade](includes/az-upgrade.md)]
-
 ### Differences between Bash and PowerShell
 
 Although most Azure CLI documentation is written and tested in a Bash shell, you can also install and run the Azure CLI using PowerShell. There are subtle syntax differences between Bash and PowerShell.  Review these articles to avoid scripting errors:
@@ -78,7 +74,7 @@ Although most Azure CLI documentation is written and tested in a Bash shell, you
 - [Use quotation marks in Azure CLI parameters](./use-cli-effectively.md#use-quotation-marks-in-parameters)
 - Compare syntax of CMD, PowerShell and Bash in [Query command output using JMESPath](./query-azure-cli.md)
 
-There are also error handling differences and the ability to enable tab completion.  See these articles for more information:
+When running the Azure CLI in PowerShell, there are also error handling differences and the ability to enable tab completion.  See these articles for more information:
 - [Error handling for the Azure CLI in PowerShell](./use-cli-effectively.md#error-handling-for-azure-cli-in-powershell)
 - [Enable Tab Completion in PowerShell](#enable-tab-completion-in-powershell)
 
@@ -102,6 +98,10 @@ The `-e` option is to ensure the official Azure CLI package is installed. This c
 ## Run the Azure CLI
 
 You can now run the Azure CLI with the `az` command from either Windows Command Prompt or PowerShell.
+
+## Update the Azure CLI
+
+[!INCLUDE [az upgrade](includes/az-upgrade.md)]
 
 ## Enable Tab Completion in PowerShell
 

--- a/docs-ref-conceptual/install-azure-cli-windows.md
+++ b/docs-ref-conceptual/install-azure-cli-windows.md
@@ -53,7 +53,6 @@ Although most Azure CLI documentation is written and tested in a Bash shell, you
 - [Quoting issues with PowerShell](https://github.com/Azure/azure-cli/blob/dev/doc/quoting-issues-with-powershell.md)
 - [Use quotation marks in Azure CLI parameters](./use-cli-effectively.md#use-quotation-marks-in-parameters)
 - Compare syntax of CMD, PowerShell and Bash in [Query command output using JMESPath](./query-azure-cli.md)
-- [Error handling for the Azure CLI in PowerShell](./use-cli-effectively.md#error-handling-for-azure-cli-in-powershell)
 
 To install the Azure CLI using PowerShell, start PowerShell **as administrator** and run the following command:
 
@@ -69,11 +68,15 @@ To install a specific version, replace the `-Uri` argument with the URL describe
    $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri https://azcliprod.blob.core.windows.net/msi/azure-cli-2.51.0.msi -OutFile .\AzureCLI.msi; Start-Process msiexec.exe -Wait -ArgumentList '/I AzureCLI.msi /quiet'; Remove-Item .\AzureCLI.msi
    ```
 
+When working with the Azure CLI in PowerShell, be aware of error handling differences and the ability to enable tab completion.
+- [Error handling for the Azure CLI in PowerShell](./use-cli-effectively.md#error-handling-for-azure-cli-in-powershell)
+- [Enable Tab Completion in PowerShell](enable-tab-completion-in-powerShell)
+
 ### Specific version
 
 [!INCLUDE [specific version](includes/specific-version.md)]
 
-### Azure CLI Command (for update only)
+### Update the Azure CLI
 
 [!INCLUDE [az upgrade](includes/az-upgrade.md)]
 
@@ -98,38 +101,9 @@ The `-e` option is to ensure the official Azure CLI package is installed. This c
 
 You can now run the Azure CLI with the `az` command from either Windows Command Prompt or PowerShell.
 
-## Enable Tab Completion on PowerShell
+## Enable Tab Completion in PowerShell
 
-PowerShell provides completion on inputs to provide hints, enable discovery and speed up input entry. Command names, command group names, parameters and certain parameter values can be completed by pressing the <kbd>Tab</kbd> key.
-
-> [!Note]
-> Azure CLI version 2.49 or higher is required to enable tab completion for Azure CLI on PowerShell.
-
-To enable tab completion in PowerShell, create or edit the profile stored in the variable `$PROFILE`. The simplest way is to run `notepad $PROFILE` in PowerShell. For more information, see [How to create your profile](/powershell/module/microsoft.powershell.core/about/about_profiles#how-to-create-a-profile) and [Profiles and execution policy](/powershell/module/microsoft.powershell.core/about/about_profiles#profiles-and-execution-policy).
-
-Then add the following code to your PowerShell profile:
-
-```powershell
-Register-ArgumentCompleter -Native -CommandName az -ScriptBlock {
-    param($commandName, $wordToComplete, $cursorPosition)
-    $completion_file = New-TemporaryFile
-    $env:ARGCOMPLETE_USE_TEMPFILES = 1
-    $env:_ARGCOMPLETE_STDOUT_FILENAME = $completion_file
-    $env:COMP_LINE = $wordToComplete
-    $env:COMP_POINT = $cursorPosition
-    $env:_ARGCOMPLETE = 1
-    $env:_ARGCOMPLETE_SUPPRESS_SPACE = 0
-    $env:_ARGCOMPLETE_IFS = "`n"
-    $env:_ARGCOMPLETE_SHELL = 'powershell'
-    az 2>&1 | Out-Null
-    Get-Content $completion_file | Sort-Object | ForEach-Object {
-        [System.Management.Automation.CompletionResult]::new($_, $_, "ParameterValue", $_)
-    }
-    Remove-Item $completion_file, Env:\_ARGCOMPLETE_STDOUT_FILENAME, Env:\ARGCOMPLETE_USE_TEMPFILES, Env:\COMP_LINE, Env:\COMP_POINT, Env:\_ARGCOMPLETE, Env:\_ARGCOMPLETE_SUPPRESS_SPACE, Env:\_ARGCOMPLETE_IFS, Env:\_ARGCOMPLETE_SHELL
-}
-```
-
-To display all available options in the  menu, add `Set-PSReadlineKeyHandler -Key Tab -Function MenuComplete` to your PowerShell profile.
+[!INCLUDE [tab-completion](includes/tab-completion.md)]
 
 ## Troubleshooting
 

--- a/docs-ref-conceptual/install-azure-cli-windows.md
+++ b/docs-ref-conceptual/install-azure-cli-windows.md
@@ -5,7 +5,7 @@ author: jiasli
 ms.author: jiasli
 manager: yonzhan
 ms.service: azure-cli
-ms.date: 08/2/2023
+ms.date: 09/13/2023
 ms.topic: conceptual
 ms.tool: azure-cli
 ms.custom: devx-track-azurecli, seo-azure-cli
@@ -59,7 +59,7 @@ To install the Azure CLI using PowerShell, start PowerShell **as administrator**
 
 This will download and install the latest 32-bit installer of the Azure CLI for Windows. If you prefer a 64-bit install, change URL to `https://aka.ms/installazurecliwindowsx64`. If the Azure CLI is already installed, the installer will overwrite the existing version.
 
-To install a specific version, replace the `-Uri` argument with the URL described in [Specific version](#specific-version-1).  Here is an example of using the 32-bit installer of the Azure CLI version [2.51.0](/cli/azure/release-notes-azure-cli#august-01-2023) in PowerShell:
+To install a specific version, replace the `-Uri` argument with the URL described in [Specific version](#specific-version-1). Here is an example of using the 32-bit installer of the Azure CLI version [2.51.0](/cli/azure/release-notes-azure-cli#august-01-2023) in PowerShell:
 
    ```PowerShell
    $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri https://azcliprod.blob.core.windows.net/msi/azure-cli-2.51.0.msi -OutFile .\AzureCLI.msi; Start-Process msiexec.exe -Wait -ArgumentList '/I AzureCLI.msi /quiet'; Remove-Item .\AzureCLI.msi
@@ -71,12 +71,12 @@ To install a specific version, replace the `-Uri` argument with the URL describe
 
 ### Differences between Bash and PowerShell
 
-Although most Azure CLI documentation is written and tested in a Bash shell, you can also install and run the Azure CLI using PowerShell. There are subtle syntax differences between Bash and PowerShell.  Review these articles to avoid scripting errors:
+Although most Azure CLI documentation is written and tested in a Bash shell, you can also install and run the Azure CLI using PowerShell. There are subtle syntax differences between Bash and PowerShell. Review these articles to avoid scripting errors:
 - [Quoting issues with PowerShell](https://github.com/Azure/azure-cli/blob/dev/doc/quoting-issues-with-powershell.md)
 - [Use quotation marks in Azure CLI parameters](./use-cli-effectively.md#use-quotation-marks-in-parameters)
 - Compare syntax of CMD, PowerShell and Bash in [Query command output using JMESPath](./query-azure-cli.md)
 
-When running the Azure CLI in PowerShell, there are also error handling differences and the ability to enable tab completion.  See these articles for more information:
+When running the Azure CLI in PowerShell, there are also error handling differences and the ability to enable tab completion. See these articles for more information:
 - [Error handling for the Azure CLI in PowerShell](./use-cli-effectively.md#error-handling-for-azure-cli-in-powershell)
 - [Enable Tab Completion in PowerShell](#enable-tab-completion-in-powershell)
 
@@ -138,9 +138,9 @@ Follow these steps to migrate to Azure CLI 64-bit:
 1. Check your current CLI version and installed extensions by running `az --version`.
 1. Extensions will need to be reinstalled. It is recommended to perform a backup of the current extension folder `%userprofile%\.azure\cliextensions` by renaming it in case you choose to revert back to 32-bit. This folder is created automatically when you reinstall an extension.
 1. Download and install latest 64-bit installer as described in [Install or update](#install-or-update). The 32-bit MSI will be automatically uninstalled.
-1. Install extensions by running `az extension add --name <extension> --version <version>`.  If you don't want to reinstall extensions manually, the Azure CLI will prompt you to install an extension on first use. For more information on installing extensions, see [How to install extensions](/cli/azure/azure-cli-extensions-overview#how-to-install-extensions).
+1. Install extensions by running `az extension add --name <extension> --version <version>`. If you don't want to reinstall extensions manually, the Azure CLI will prompt you to install an extension on first use. For more information on installing extensions, see [How to install extensions](/cli/azure/azure-cli-extensions-overview#how-to-install-extensions).
 
-If you have issues after migration, you can uninstall the 64-bit and reinstall the 32-bit MSI.  If you have made a backup of your 32-bit extension folder, restore (rename) your extension folder after the change.
+If you have issues after migration, you can uninstall the 64-bit and reinstall the 32-bit MSI. If you have made a backup of your 32-bit extension folder, restore (rename) your extension folder after the change.
 
 ## Update the Azure CLI
 

--- a/docs-ref-conceptual/install-azure-cli-windows.md
+++ b/docs-ref-conceptual/install-azure-cli-windows.md
@@ -43,6 +43,8 @@ If you have previously installed the Azure CLI, running either the 32-bit or 64-
 
 ### Specific version
 
+If you prefer, you can download a specific version of the Azure CLI by using a URL.
+
 [!INCLUDE [specific version](includes/specific-version.md)]
 
 # [Microsoft Installer (MSI) with PowerShell](#tab/powershell)

--- a/docs-ref-conceptual/install-azure-cli-windows.md
+++ b/docs-ref-conceptual/install-azure-cli-windows.md
@@ -49,11 +49,6 @@ If you have previously installed the Azure CLI, running either the 32-bit or 64-
 
 ### PowerShell
 
-Although most Azure CLI documentation is written and tested in a Bash shell, you can also install and run the Azure CLI using PowerShell. There are subtle syntax differences between Bash and PowerShell.  Review these articles to avoid scripting errors:
-- [Quoting issues with PowerShell](https://github.com/Azure/azure-cli/blob/dev/doc/quoting-issues-with-powershell.md)
-- [Use quotation marks in Azure CLI parameters](./use-cli-effectively.md#use-quotation-marks-in-parameters)
-- Compare syntax of CMD, PowerShell and Bash in [Query command output using JMESPath](./query-azure-cli.md)
-
 To install the Azure CLI using PowerShell, start PowerShell **as administrator** and run the following command:
 
    ```PowerShell
@@ -68,10 +63,6 @@ To install a specific version, replace the `-Uri` argument with the URL describe
    $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri https://azcliprod.blob.core.windows.net/msi/azure-cli-2.51.0.msi -OutFile .\AzureCLI.msi; Start-Process msiexec.exe -Wait -ArgumentList '/I AzureCLI.msi /quiet'; Remove-Item .\AzureCLI.msi
    ```
 
-When working with the Azure CLI in PowerShell, be aware of error handling differences and the ability to enable tab completion.
-- [Error handling for the Azure CLI in PowerShell](./use-cli-effectively.md#error-handling-for-azure-cli-in-powershell)
-- [Enable Tab Completion in PowerShell](#enable-tab-completion-in-powershell)
-
 ### Specific version
 
 [!INCLUDE [specific version](includes/specific-version.md)]
@@ -79,6 +70,17 @@ When working with the Azure CLI in PowerShell, be aware of error handling differ
 ### Update the Azure CLI
 
 [!INCLUDE [az upgrade](includes/az-upgrade.md)]
+
+### Differences between Bash and PowerShell
+
+Although most Azure CLI documentation is written and tested in a Bash shell, you can also install and run the Azure CLI using PowerShell. There are subtle syntax differences between Bash and PowerShell.  Review these articles to avoid scripting errors:
+- [Quoting issues with PowerShell](https://github.com/Azure/azure-cli/blob/dev/doc/quoting-issues-with-powershell.md)
+- [Use quotation marks in Azure CLI parameters](./use-cli-effectively.md#use-quotation-marks-in-parameters)
+- Compare syntax of CMD, PowerShell and Bash in [Query command output using JMESPath](./query-azure-cli.md)
+
+There are also error handling differences and the ability to enable tab completion.  See these articles for more information:
+- [Error handling for the Azure CLI in PowerShell](./use-cli-effectively.md#error-handling-for-azure-cli-in-powershell)
+- [Enable Tab Completion in PowerShell](#enable-tab-completion-in-powershell)
 
 # [Windows Package Manager](#tab/winget)
 

--- a/docs-ref-conceptual/install-azure-cli-windows.md
+++ b/docs-ref-conceptual/install-azure-cli-windows.md
@@ -70,7 +70,7 @@ To install a specific version, replace the `-Uri` argument with the URL describe
 
 When working with the Azure CLI in PowerShell, be aware of error handling differences and the ability to enable tab completion.
 - [Error handling for the Azure CLI in PowerShell](./use-cli-effectively.md#error-handling-for-azure-cli-in-powershell)
-- [Enable Tab Completion in PowerShell](enable-tab-completion-in-powerShell)
+- [Enable Tab Completion in PowerShell](#enable-tab-completion-in-powershell)
 
 ### Specific version
 

--- a/docs-ref-conceptual/install-azure-cli-windows.md
+++ b/docs-ref-conceptual/install-azure-cli-windows.md
@@ -166,7 +166,7 @@ If you don't plan to reinstall Azure CLI, remove its data from `C:\Users\<userna
 
 ## Next Steps
 
-Now that you've installed the Azure CLI on Windows, take a short tour of its features and common commands.
+Now that you've installed the Azure CLI on Windows, learn about the different ways to sign in.
 
 > [!div class="nextstepaction"]
-> [Get started with the Azure CLI](get-started-with-azure-cli.md)
+> [Sign in with Azure CLI](authenticate-azure-cli.md)

--- a/docs-ref-conceptual/install-azure-cli-windows.md
+++ b/docs-ref-conceptual/install-azure-cli-windows.md
@@ -41,6 +41,10 @@ Download and install the latest release of the Azure CLI. When the installer ask
 
 If you have previously installed the Azure CLI, running either the 32-bit or 64-bit MSI will overwrite an existing installation.
 
+### Specific version
+
+[!INCLUDE [specific version](includes/specific-version.md)]
+
 # [Microsoft Installer (MSI) with PowerShell](#tab/powershell)
 
 ### PowerShell
@@ -53,7 +57,7 @@ To install the Azure CLI using PowerShell, start PowerShell **as administrator**
 
 This will download and install the latest 32-bit installer of the Azure CLI for Windows. If you prefer a 64-bit install, change URL to `https://aka.ms/installazurecliwindowsx64`. If the Azure CLI is already installed, the installer will overwrite the existing version.
 
-To install a specific version, replace the `-Uri` argument with the URL described in [Specific version](#specific-version).  Here is an example of using the 32-bit installer of the Azure CLI version [2.51.0](/cli/azure/release-notes-azure-cli#august-01-2023) in PowerShell:
+To install a specific version, replace the `-Uri` argument with the URL described in [Specific version](#specific-version-1).  Here is an example of using the 32-bit installer of the Azure CLI version [2.51.0](/cli/azure/release-notes-azure-cli#august-01-2023) in PowerShell:
 
    ```PowerShell
    $ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri https://azcliprod.blob.core.windows.net/msi/azure-cli-2.51.0.msi -OutFile .\AzureCLI.msi; Start-Process msiexec.exe -Wait -ArgumentList '/I AzureCLI.msi /quiet'; Remove-Item .\AzureCLI.msi

--- a/docs-ref-conceptual/install-azure-cli-windows.md
+++ b/docs-ref-conceptual/install-azure-cli-windows.md
@@ -41,11 +41,7 @@ Download and install the latest release of the Azure CLI. When the installer ask
 
 If you have previously installed the Azure CLI, running either the 32-bit or 64-bit MSI will overwrite an existing installation.
 
-### Specific version
-
-[!INCLUDE [specific version](includes/specific-version.md)]
-
-# [Microsoft Installer (MSI) with Command](#tab/powershell)
+# [Microsoft Installer (MSI) with PowerShell](#tab/powershell)
 
 ### PowerShell
 
@@ -99,10 +95,6 @@ The `-e` option is to ensure the official Azure CLI package is installed. This c
 
 You can now run the Azure CLI with the `az` command from either Windows Command Prompt or PowerShell.
 
-## Update the Azure CLI
-
-[!INCLUDE [az upgrade](includes/az-upgrade.md)]
-
 ## Enable Tab Completion in PowerShell
 
 [!INCLUDE [tab-completion](includes/tab-completion.md)]
@@ -143,6 +135,10 @@ Follow these steps to migrate to Azure CLI 64-bit:
 1. Install extensions by running `az extension add --name <extension> --version <version>`.  If you don't want to reinstall extensions manually, the Azure CLI will prompt you to install an extension on first use. For more information on installing extensions, see [How to install extensions](/cli/azure/azure-cli-extensions-overview#how-to-install-extensions).
 
 If you have issues after migration, you can uninstall the 64-bit and reinstall the 32-bit MSI.  If you have made a backup of your 32-bit extension folder, restore (rename) your extension folder after the change.
+
+## Update the Azure CLI
+
+[!INCLUDE [az upgrade](includes/az-upgrade.md)]
 
 ## Uninstall
 

--- a/docs-ref-conceptual/use-cli-effectively.md
+++ b/docs-ref-conceptual/use-cli-effectively.md
@@ -416,6 +416,10 @@ foreach ($vm_id in $vm_ids) {
 
 ---
 
+## Enable Tab Completion in PowerShell
+
+[!INCLUDE [tab-completion](includes/tab-completion.md)]
+
 ## Error handling for Azure CLI in PowerShell
 
 You can run Azure CLI commands in PowerShell, as described in [Choose the right Azure command-line tool](choose-the-right-azure-command-line-tool.md). If you do, be sure you understand Azure CLI error handling in PowerShell. In particular, Azure CLI doesn't create exceptions for PowerShell to catch.

--- a/docs-ref-conceptual/use-cli-effectively.md
+++ b/docs-ref-conceptual/use-cli-effectively.md
@@ -4,7 +4,7 @@ description: Learn tips for using Azure CLI successfully, such as output formats
 manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
-ms.date: 08/2/2023
+ms.date: 09/13/2023
 ms.topic: conceptual
 ms.service: azure-cli
 ms.tool: azure-cli
@@ -13,7 +13,7 @@ ms.custom: devx-track-azurecli, seo-azure-cli
 
 # Tips for using the Azure CLI successfully
 
-Azure CLI is a command-line tool that allows you to configure and manage Azure resources from many shell environments.  First [choose the right command-line tool](./choose-the-right-azure-command-line-tool.md#different-shell-environments) and [install](./install-azure-cli.md) the Azure CLI.  Then use this article to discover useful tips on how to avoid common pitfalls and use the Azure CLI successfully.
+Azure CLI is a command-line tool that allows you to configure and manage Azure resources from many shell environments. First [choose the right command-line tool](./choose-the-right-azure-command-line-tool.md#different-shell-environments) and [install](./install-azure-cli.md) the Azure CLI.  Then use this article to discover useful tips on how to avoid common pitfalls and use the Azure CLI successfully.
 
 To learn more about specific Azure CLI commands, see the [Azure CLI Reference list](../latest/docs-ref-autogen/reference-index.yml).
 
@@ -122,9 +122,9 @@ To avoid unanticipated results, here are a few suggestions:
 
 - In Bash or PowerShell, both single and double quotes are interpreted correctly. In Windows Command Prompt, only double quotes are interpreted correctly -- single quotes are treated as part of the value.
 
-- If your command is only going to run on Bash (or Zsh), use single quotes to preserve the content inside the JSON string. Single quotes are necessary when supplying inline JSON values.  For example, this JSON is correct in Bash: `'{"key": "value"}'`.
+- If your command is only going to run on Bash (or Zsh), use single quotes to preserve the content inside the JSON string. Single quotes are necessary when supplying inline JSON values. For example, this JSON is correct in Bash: `'{"key": "value"}'`.
 
-- If your command runs at a Windows Command Prompt, you must use double quotes.  If the value contains double quotes, you must escape it.  The equivalent of the above JSON string is `"{\"key\": \"value\"}"`
+- If your command runs at a Windows Command Prompt, you must use double quotes. If the value contains double quotes, you must escape it. The equivalent of the above JSON string is `"{\"key\": \"value\"}"`
 
 - In PowerShell, if your value is an empty string, use `'""'`.
 
@@ -151,7 +151,7 @@ To avoid unanticipated results, here are a few suggestions:
     1. Quoted space-separated list
        `--parameterName "firstValue" "secondValue"`
 
-    This example is a string with a space in it.  It isn't a space-separated list:
+    This example is a string with a space in it. It isn't a space-separated list:
        `--parameterName "firstValue secondValue"`
 
 - There are special characters of PowerShell, such as at `@`. To run Azure CLI in PowerShell, add `` ` `` before the special character to escape it. You can also enclose the value in single or double quotes `"`/`"`.
@@ -219,7 +219,7 @@ To avoid unanticipated results, here are a few suggestions:
 
   ---
 
-- The best way to troubleshoot a quoting issue is to run the command with the `--debug` flag.  This flag reveals the actual arguments received by the Azure CLI in [Python's syntax](https://docs.python.org/3/tutorial/introduction.html#strings).
+- The best way to troubleshoot a quoting issue is to run the command with the `--debug` flag. This flag reveals the actual arguments received by the Azure CLI in [Python's syntax](https://docs.python.org/3/tutorial/introduction.html#strings).
 
   ```bash
   # Correct
@@ -245,7 +245,7 @@ If a parameter's value begins with a hyphen, Azure CLI tries to parse it as a pa
 
 ## Asynchronous operations
 
-Operations in Azure can take a noticeable amount of time. For instance, configuring a virtual machine at a data center isn't instantaneous. Azure CLI waits until the command has finished to accept other commands.  Many commands therefore offer a `--no-wait` parameter as shown here:
+Operations in Azure can take a noticeable amount of time. For instance, configuring a virtual machine at a data center isn't instantaneous. Azure CLI waits until the command has finished to accept other commands. Many commands therefore offer a `--no-wait` parameter as shown here:
 
 ```azurecli
 az group delete --name MyResourceGroup --no-wait
@@ -363,7 +363,7 @@ When using `--uri-parameters` for requests in the form of OData, make sure to es
 
 ## Script examples
 
-Here are examples for using variables and looping through a list when working with Azure Virtual Machines.  For in-depth examples on using Bash constructs with the Azure CLI including loops, case statements, if..then..else, and error handling, see [Learn to use Bash with the Azure CLI](./azure-cli-learn-bash.md).
+Here are examples for using variables and looping through a list when working with Azure Virtual Machines. For in-depth examples on using Bash constructs with the Azure CLI including loops, case statements, if..then..else, and error handling, see [Learn to use Bash with the Azure CLI](./azure-cli-learn-bash.md).
 
 Use these scripts to save IDs to variables:
 


### PR DESCRIPTION
- updated tab-completion information to use a numbered list
- moved tab completion to /Include
- added tab completion information to use-cli-effectively.md
- reworded specific-version.md so that it applied better to both Windows and PowerSell tabs
- consolidate links for Bash vs PowerShell tips on Install using PowerShell tab