### PR TITLE
fixed tenant information

### DIFF
--- a/docs-ref-conceptual/manage-azure-subscriptions-azure-cli.md
+++ b/docs-ref-conceptual/manage-azure-subscriptions-azure-cli.md
@@ -4,7 +4,7 @@ description: Learn about Azure tenants, users, and subscriptions. Use Azure CLI 
 manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
-ms.date: 08/2/2023
+ms.date: 09/13/2023
 ms.topic: conceptual
 ms.service: azure-cli
 ms.tool: azure-cli
@@ -14,13 +14,13 @@ keywords: Azure subscriptions, manage azure subscriptions, azure management grou
 
 # How to manage Azure subscriptions with the Azure CLI
 
-The Azure CLI helps you manage your Azure subscription, create management groups, and lock subscriptions.  You might have multiple subscriptions within Azure. You can be part of more than one organization or your organization might divide access to certain resources across groupings. The Azure CLI supports selecting a subscription both globally and per command.
+The Azure CLI helps you manage your Azure subscription, create management groups, and lock subscriptions.You might have multiple subscriptions within Azure. You can be part of more than one organization or your organization might divide access to certain resources across groupings. The Azure CLI supports selecting a subscription both globally and per command.
 
 For detailed information on subscriptions, billing, and cost management, see the [billing and cost management documentation](/azure/billing/).
 
 ## Tenants, users, and subscriptions
 
-A _tenant_ is the Azure Active Directory entity that encompasses a whole organization. A tenant has one or more _subscriptions_ and _users_. Users are those accounts that sign in to Azure to create, manage, and use resources. A user may have access to multiple _subscriptions_, but a user is only associated with a single tenant.  _Subscriptions_ are the agreements with Microsoft to use cloud services, including Azure. Every resource is associated with a subscription.
+A _tenant_ is the Azure Active Directory entity that encompasses a whole organization. A tenant has one or more _subscriptions_ and _users_. Users are those accounts that sign in to Azure to create, manage, and use resources. A user may have access to multiple _subscriptions_, but a user is only associated with a single tenant. _Subscriptions_ are the agreements with Microsoft to use cloud services, including Azure. Every resource is associated with a subscription.
 
 To learn more about the differences between tenants, users, and subscriptions, see the [Azure cloud terminology dictionary](/azure/azure-glossary-cloud-terminology).
 
@@ -35,7 +35,7 @@ az account show
 
 ## Change the active tenant
 
-To switch tenants, you need to sign in as a user within the desired tenant.  Use [az login](/cli/azure/reference-index#az-login-examples) to change the active tenant and update the subscription list to which you belong.
+To switch tenants, you need to sign in as a user within the desired tenant. Use [az login](/cli/azure/reference-index#az-login-examples) to change the active tenant and update the subscription list to which you belong.
 
 ```azurecli-interactive
 # sign in as a different user
@@ -51,13 +51,13 @@ If your organization requires multi-factor authentication, you may receive this 
 Due to a configuration change made by your administrator, or because you moved to a new location, you must use multi-factor authentication to access...
 ```
 
-Using the alternative `az login --tenant` command prompts you to open an HTTPS page and enter the code provided.  You can then use multi-factor authentication and successfully sign in.  To learn more about sign in options with the azure CLI, see [Sign in with the Azure CLI](./authenticate-azure-cli.md).
+Using the alternative `az login --tenant` command prompts you to open an HTTPS page and enter the code provided. You can then use multi-factor authentication and successfully sign in. To learn more about sign in options with the azure CLI, see [Sign in with the Azure CLI](./authenticate-azure-cli.md).
 
 ## Get the active subscription
 
 Most Azure CLI commands act within a subscription. You can specify which subscription to work in by using the `--subscription` parameter in your command. If you don't specify a subscription, the command uses your current, active subscription. 
 
-To see the subscription you're currently using or to get a list of available subscriptions, run the [az account show](/cli/azure/account#az-account-show) or [az account list](/cli/azure/account#az-account-list) command.  Go to [Learn to use Bash with the Azure CLI](azure-cli-learn-bash.md#querying-and-formatting-single-values-and-nested-values) to see more examples of ways to use `az account show`.
+To see the subscription you're currently using or to get a list of available subscriptions, run the [az account show](/cli/azure/account#az-account-show) or [az account list](/cli/azure/account#az-account-list) command. Go to [Learn to use Bash with the Azure CLI](azure-cli-learn-bash.md#querying-and-formatting-single-values-and-nested-values) to see more examples of ways to use `az account show`.
 
 ```azurecli-interactive
 # get the current default subscription using show
@@ -66,7 +66,7 @@ az account show --output table
 # get the current default subscription using list
 az account list --query "[?isDefault]"
 
-# store the default subscription  in a variable
+# store the default subscription in a variable
 subscriptionId="$(az account list --query "[?isDefault].id" -o tsv)"
 echo $subscriptionId
 ```
@@ -78,7 +78,7 @@ Subscriptions contain resource groups. An Azure resource group is a container th
 
 ## Change the active subscription
 
-Azure subscriptions have both a name and an ID.  You can switch to a different subscription using [az account set](/cli/azure/account#az-account-set) specifying the desired subscription ID or name.
+Azure subscriptions have both a name and an ID. You can switch to a different subscription using [az account set](/cli/azure/account#az-account-set) specifying the desired subscription ID or name.
 
 ```azurecli-interactive
 # change the active subscription using the subscription name

--- a/docs-ref-conceptual/manage-azure-subscriptions-azure-cli.md
+++ b/docs-ref-conceptual/manage-azure-subscriptions-azure-cli.md
@@ -62,11 +62,13 @@ To switch tenants, you have two options.
 
     Using the alternative `az login --tenant` command prompts you to open an HTTPS page and enter the code provided. You can then use multi-factor authentication and successfully sign in. To learn more about sign in options with the azure CLI, see [Sign in with the Azure CLI](./authenticate-azure-cli.md).
 
-## Get the active subscription
+## Get subscription information
 
 Most Azure CLI commands act within a subscription. You can specify which subscription to work in by using the `--subscription` parameter in your command. If you don't specify a subscription, the command uses your current, active subscription.
 
-To see the subscription you're currently using or to get a list of available subscriptions, run the [az account show](/cli/azure/account#az-account-show) or [az account list](/cli/azure/account#az-account-list) command. Go to [Learn to use Bash with the Azure CLI](azure-cli-learn-bash.md#querying-and-formatting-single-values-and-nested-values) to see more examples of ways to use `az account show`.
+To see the subscription you're currently using or to get a list of available subscriptions, run the [az account show](/cli/azure/account#az-account-show) or [az account list](/cli/azure/account#az-account-list) command. Go to [Learn to use Bash with the Azure CLI](azure-cli-learn-bash.md#querying-and-formatting-single-values-and-nested-values) to see more examples of ways to use these commands.
+
+Here are examples showing how to get subscription information:
 
 ```azurecli-interactive
 # get the current default subscription using show
@@ -75,8 +77,15 @@ az account show --output table
 # get the current default subscription using list
 az account list --query "[?isDefault]"
 
+# get a subscription that contains search words or phrases
+az account list --query "[?contains(name,'search phrase')].{SubscriptionName:name, SubscriptionID:id, TenantID:tenantId}" --output table
+
 # store the default subscription in a variable
-subscriptionId="$(az account list --query "[?isDefault].id" -o tsv)"
+subscriptionId="$(az account list --query "[?isDefault].id" --output tsv)"
+echo $subscriptionId
+
+# store a subscription of certain name in a variable
+subscriptionId="$(az account list --query "[?name=='my case sensitive subscription full name'].id" --output tsv)"
 echo $subscriptionId
 ```
 
@@ -95,13 +104,13 @@ az account set --subscription "My Demos"
 az account set --subscription "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
 # change the active subscription using a variable
-subscriptionId="$(az account list --query "[?isDefault].id" -o tsv)"
+subscriptionId="$(az account list --query "[?name=='my case sensitive subscription full name'].id" --output tsv)"
 az account set --subscription $subscriptionId
 ```
 
 If you change to a subscription that is in a different tenant, you will also be changing the active tenant. To learn how to add a new subscription to your Azure Active Directory tenant, see [Associate or add an Azure subscription to your Azure Active Directory tenant](/azure/active-directory/active-directory-how-subscriptions-associated-directory).
 
-If you received a "The subscription of ... doesn't exist...", see [Troubleshooting](#troubleshooting) for possible solutions.
+If you received a "The subscription of ... doesn't exist..." error, see [Troubleshooting](#troubleshooting) for possible solutions.
 
 ## Create Azure management groups
 

--- a/docs-ref-conceptual/manage-azure-subscriptions-azure-cli.md
+++ b/docs-ref-conceptual/manage-azure-subscriptions-azure-cli.md
@@ -4,7 +4,7 @@ description: Learn about Azure tenants, users, and subscriptions. Use Azure CLI 
 manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
-ms.date: 09/13/2023
+ms.date: 09/15/2023
 ms.topic: conceptual
 ms.service: azure-cli
 ms.tool: azure-cli
@@ -68,7 +68,7 @@ Most Azure CLI commands act within a subscription. You can specify which subscri
 
 To see the subscription you're currently using or to get a list of available subscriptions, run the [az account show](/cli/azure/account#az-account-show) or [az account list](/cli/azure/account#az-account-list) command. Go to [Learn to use Bash with the Azure CLI](azure-cli-learn-bash.md#querying-and-formatting-single-values-and-nested-values) to see more examples of ways to use these commands.
 
-Here are examples showing how to get subscription information:
+Here are examples showing how to get subscription information.
 
 ```azurecli-interactive
 # get the current default subscription using show
@@ -188,9 +188,9 @@ az account lock delete --name "Cannot delete subscription"
 
 ### The subscription doesn't exist
 
-In addition to a typographical error, you can receive this error when there is a permissions timing issue.  For example, if you have been given permissions to a new subscriptions _while your current terminal window is open_, this error can occur.  The solution is to either close and reopen your terminal window, or use `az logout` then `az login` to refresh your available subscriptions list.
+In addition to a typographical error, you can receive this error when there is a permissions timing issue. For example, if you have been given permissions to a new subscriptions _while your current terminal window is open_, this error can occur. The solution is to either close and reopen your terminal window, or use `az logout` then `az login` to refresh your available subscriptions list.
 
-Here is a script to help you find available subscriptions.
+Here is a script to help you find and change a subscription.
 
 ```azurecli
 # See what subscription you are currently using.
@@ -209,7 +209,7 @@ az login
 az account list --output table
 
 # If the subscription you are seeking is still not in the list,
-#    contact your system administrator.  You cannot change your
+#    contact your system administrator. You cannot change your
 #    subscription to an ID that is not in the list.
 
 # If the subscription you are seeking is now in the list,

--- a/docs-ref-conceptual/manage-azure-subscriptions-azure-cli.md
+++ b/docs-ref-conceptual/manage-azure-subscriptions-azure-cli.md
@@ -18,15 +18,20 @@ The Azure CLI helps you manage your Azure subscription, create management groups
 
 For detailed information on subscriptions, billing, and cost management, see the [billing and cost management documentation](/azure/billing/).
 
-## Tenants, users, and subscriptions
+## Terminology
 
-A _tenant_ is the Azure Active Directory entity that encompasses a whole organization. A tenant has one or more _subscriptions_ and _users_. Users are those accounts that sign in to Azure to create, manage, and use resources. A user may have access to multiple _subscriptions_, but a user is only associated with a single tenant. _Subscriptions_ are the agreements with Microsoft to use cloud services, including Azure. Every resource is associated with a subscription.
+A _tenant_ is an instance of Azure AD in which information about a single organization resides. A _[multi-tenant organization](/azure/active-directory/multi-tenant-organizations/overview)_ is an organization that has more than one instance of Azure AD. A tenant has one or more _subscriptions_ and _users_.
 
-To learn more about the differences between tenants, users, and subscriptions, see the [Azure cloud terminology dictionary](/azure/azure-glossary-cloud-terminology).
+Users are those accounts that sign in to Azure to create, manage, and use resources. A user may have access to multiple _tenants_ and _subscriptions_.
+
+_[Subscriptions](/azure/cloud-adoption-framework/ready/landing-zone/design-area/resource-org-subscriptions)_ are the agreements with Microsoft to use cloud services, including Azure. Every resource is associated with a subscription. Subscriptions contain resource groups.
+
+An Azure _resource group_ is a container that holds related resources for an Azure solution. To learn how to manage resource groups within your subscription, see [How to manage Azure resource groups with the Azure CLI](manage-azure-groups-azure-cli.md)
 
 ## Get the active tenant
 
 Use [az account tenant list](/cli/azure/account/tenant) or [az account show](/cli/azure/account#az-account-show) to get the active tenant ID.
+
 ```azurecli-interactive
 az account tenant list
 
@@ -35,27 +40,31 @@ az account show
 
 ## Change the active tenant
 
-To switch tenants, you need to sign in as a user within the desired tenant. Use [az login](/cli/azure/reference-index#az-login-examples) to change the active tenant and update the subscription list to which you belong.
+To switch tenants, you have two options.
 
-```azurecli-interactive
-# sign in as a different user
-az login --user <myAlias@myCompany.com> -password <myPassword>
+- [Change the active subscription.](#change-the-active-subscription)
 
-# sign in with a different tenant
-az login --tenant <myTenantID>
-```
+- Sign in as a user within the desired tenant. Use [az login](/cli/azure/reference-index#az-login-examples) to change the active tenant and update the subscription list to which you belong.
 
-If your organization requires multi-factor authentication, you may receive this error when using `az login --user`:
+    ```azurecli-interactive
+    # sign in as a different user
+    az login --user <myAlias@myCompany.com> -password <myPassword>
+    
+    # sign in with a different tenant
+    az login --tenant <myTenantID>
+    ```
 
-```output
-Due to a configuration change made by your administrator, or because you moved to a new location, you must use multi-factor authentication to access...
-```
+    If your organization requires multi-factor authentication, you may receive this error when using `az login --user`:
 
-Using the alternative `az login --tenant` command prompts you to open an HTTPS page and enter the code provided. You can then use multi-factor authentication and successfully sign in. To learn more about sign in options with the azure CLI, see [Sign in with the Azure CLI](./authenticate-azure-cli.md).
+    ```output
+    Due to a configuration change made by your administrator, or because you moved to a new location, you must use multi-factor authentication to access...
+    ```
+
+    Using the alternative `az login --tenant` command prompts you to open an HTTPS page and enter the code provided. You can then use multi-factor authentication and successfully sign in. To learn more about sign in options with the azure CLI, see [Sign in with the Azure CLI](./authenticate-azure-cli.md).
 
 ## Get the active subscription
 
-Most Azure CLI commands act within a subscription. You can specify which subscription to work in by using the `--subscription` parameter in your command. If you don't specify a subscription, the command uses your current, active subscription. 
+Most Azure CLI commands act within a subscription. You can specify which subscription to work in by using the `--subscription` parameter in your command. If you don't specify a subscription, the command uses your current, active subscription.
 
 To see the subscription you're currently using or to get a list of available subscriptions, run the [az account show](/cli/azure/account#az-account-show) or [az account list](/cli/azure/account#az-account-list) command. Go to [Learn to use Bash with the Azure CLI](azure-cli-learn-bash.md#querying-and-formatting-single-values-and-nested-values) to see more examples of ways to use `az account show`.
 
@@ -74,8 +83,6 @@ echo $subscriptionId
 > [!TIP]
 > The `--output` parameter is a global parameter, available for all commands. The **table** value presents output in a friendly format. For more information, see [Output formats for Azure CLI commands](./format-output-azure-cli.md).
 
-Subscriptions contain resource groups. An Azure resource group is a container that holds related resources for an Azure solution. To learn how to manage resource groups within your subscription, see [How to manage Azure resource groups with the Azure CLI](manage-azure-groups-azure-cli.md)
-
 ## Change the active subscription
 
 Azure subscriptions have both a name and an ID. You can switch to a different subscription using [az account set](/cli/azure/account#az-account-set) specifying the desired subscription ID or name.
@@ -93,6 +100,8 @@ az account set --subscription $subscriptionId
 ```
 
 If you change to a subscription that is in a different tenant, you will also be changing the active tenant. To learn how to add a new subscription to your Azure Active Directory tenant, see [Associate or add an Azure subscription to your Azure Active Directory tenant](/azure/active-directory/active-directory-how-subscriptions-associated-directory).
+
+If you received a "The subscription of ... doesn't exist...", see [Troubleshooting](#troubleshooting) for possible solutions.
 
 ## Create Azure management groups
 
@@ -166,8 +175,40 @@ You can remove a lock by using the [az account lock delete](/cli/azure/account/l
 az account lock delete --name "Cannot delete subscription"
 ```
 
+## Troubleshooting
+
+### The subscription doesn't exist
+
+In addition to a typographical error, you can receive this error when there is a permissions timing issue.  For example, if you have been given permissions to a new subscriptions _while your current terminal window is open_, this error can occur.  The solution is to either close and reopen your terminal window, or use `az logout` then `az login` to refresh your available subscriptions list.
+
+Here is a script to help you find available subscriptions.
+
+```azurecli
+# See what subscription you are currently using.
+az account show
+
+# Get a list of available subscriptions.
+az account list --output table
+
+# If the subscription you are seeking is not in the list
+#   close and reopen your terminal window,
+#   or logout and then sign in again.
+az logout
+az login
+
+# Did your available subscription list change?
+az account list --output table
+
+# If the subscription you are seeking is still not in the list,
+#    contact your system administrator.  You cannot change your
+#    subscription to an ID that is not in the list.
+
+# If the subscription you are seeking is now in the list,
+#   change your subscription.
+az account set --subscription 00000000-0000-0000-0000-00000000000
+```
+
 ## See also
 
-* [Azure cloud terminology dictionary](/azure/azure-glossary-cloud-terminology)
-* [Associate or add an Azure subscription to your Azure Active Directory tenant](/azure/active-directory/active-directory-how-subscriptions-associated-directory)
-* [Manage Azure resource groups](./manage-azure-groups-azure-cli.md)
+- [Associate or add an Azure subscription to your Azure Active Directory tenant](/azure/active-directory/active-directory-how-subscriptions-associated-directory)
+- [Manage Azure resource groups](./manage-azure-groups-azure-cli.md)

--- a/docs-ref-conceptual/manage-azure-subscriptions-azure-cli.md
+++ b/docs-ref-conceptual/manage-azure-subscriptions-azure-cli.md
@@ -92,13 +92,7 @@ subscriptionId="$(az account list --query "[?isDefault].id" -o tsv)"
 az account set --subscription $subscriptionId
 ```
 
-You can't change your active subscription to a subscription _within a different tenant_ using the `az account set` command.  You first must sign in as a user within the desire tenant.  If you do try to set your subscription to a subscription within a different tenant, you receive this error:
-
-```output
-The subscription of 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' doesn't exist in cloud 'AzureCloud'.
-```
-
-To learn how to add a new subscription to your Azure Active Directory tenant, see [Associate or add an Azure subscription to your Azure Active Directory tenant](/azure/active-directory/active-directory-how-subscriptions-associated-directory).
+If you change to a subscription that is in a different tenant, you will also be changing the active tenant. To learn how to add a new subscription to your Azure Active Directory tenant, see [Associate or add an Azure subscription to your Azure Active Directory tenant](/azure/active-directory/active-directory-how-subscriptions-associated-directory).
 
 ## Create Azure management groups
 


### PR DESCRIPTION
The behavior of `az account set` has changed to now automatically change the active tenant.  

![image](https://github.com/MicrosoftDocs/azure-docs-cli/assets/58762114/72e0eaaf-89cf-4d04-bd63-e39f2bb5653d)

 Additional changes made are...
- Rewrite of **Terminology** H2
- BUllet list given to **Change the active tenant** H2
- More examples using `--query` in **Get subscription information** H2
- New **Troubleshooting** H2