### PR TITLE
added redirects for Stack HCI VM

### DIFF
--- a/.openpublishing.redirection.delete-service-page.json
+++ b/.openpublishing.redirection.delete-service-page.json
@@ -2171,18 +2171,18 @@
             "redirect_document_id": false
          },
          {
-            "source_path": "2017-03-09-profile/docs-ref-autogen/service-page/Stack%HCI%VM.yml",
-            "redirect_url": "/cli/azure/service-page/Stack%HCI",
+            "source_path": "2017-03-09-profile/docs-ref-autogen/service-page/Stack HCI VM.yml",
+            "redirect_url": "/cli/azure/service-page/Stack%20HCI",
             "redirect_document_id": false
          },
          {
-            "source_path": "2018-03-01-hybrid/docs-ref-autogen/service-page/Stack%HCI%VM.yml",
-            "redirect_url": "/cli/azure/service-page/Stack%HCI",
+            "source_path": "2018-03-01-hybrid/docs-ref-autogen/service-page/Stack HCI VM.yml",
+            "redirect_url": "/cli/azure/service-page/Stack%20HCI",
             "redirect_document_id": false
          },
          {
-            "source_path": "latest/docs-ref-autogen/service-page/Stack%HCI%VM.yml",
-            "redirect_url": "/cli/azure/service-page/Stack%HCI",
+            "source_path": "latest/docs-ref-autogen/service-page/Stack HCI VM.yml",
+            "redirect_url": "/cli/azure/service-page/Stack%20HCI",
             "redirect_document_id": false
          }
     ]

--- a/.openpublishing.redirection.delete-service-page.json
+++ b/.openpublishing.redirection.delete-service-page.json
@@ -2169,6 +2169,21 @@
             "source_path": "2017-03-09-profile/docs-ref-autogen/service-page/Microsoft.StorageCache.yml",
             "redirect_url": "/cli/azure/service-page/Storage%20Cache%20-%20AML%20file%20systems",
             "redirect_document_id": false
+         },
+         {
+            "source_path": "2017-03-09-profile/docs-ref-autogen/service-page/Stack%HCI%VM.yml",
+            "redirect_url": "/cli/azure/service-page/Stack%HCI",
+            "redirect_document_id": false
+         },
+         {
+            "source_path": "2018-03-01-hybrid/docs-ref-autogen/service-page/Stack%HCI%VM.yml",
+            "redirect_url": "/cli/azure/service-page/Stack%HCI",
+            "redirect_document_id": false
+         },
+         {
+            "source_path": "latest/docs-ref-autogen/service-page/Stack%HCI%VM.yml",
+            "redirect_url": "/cli/azure/service-page/Stack%HCI",
+            "redirect_document_id": false
          }
     ]
 }


### PR DESCRIPTION
Although Stack HCI VM only existed in our reference TOC for about a day, it was put under its own top-level node, "Stack HCI VM" vs the Azure service node of "Stack HCI".  When `az stack-hci-vm` returns, hopefully, it will be placed correctly.  Regardless, we need redirects as `/cli/azure/service-page/Stack%20HCI%20VM` has been deleted.