### PR TITLE
Added output limit reference to aks command invoke

### DIFF
--- a/latest/docs-ref-autogen/aks/command.yml
+++ b/latest/docs-ref-autogen/aks/command.yml
@@ -42,7 +42,7 @@ directCommands:
 - uid: az_aks_command_result()
   name: az aks command result
   summary: |-
-    Fetch result from previously triggered 'aks command invoke'.
+    Fetch result from previously triggered 'aks command invoke'. Output is limited to 512kB in size.
   status: GA
   sourceType: Core
   editLink: https://github.com/Azure/azure-cli/blob/dev/src/azure-cli/azure/cli/command_modules/acs/_help.py


### PR DESCRIPTION
az aks command invoke will truncate output at 512kb of size. This is by design - adding a reference to public docs + CLI helper files