### PR TITLE
Update azure-cli-vm-tutorial with proper image

### DIFF
--- a/docs-ref-conceptual/azure-cli-vm-tutorial-3.md
+++ b/docs-ref-conceptual/azure-cli-vm-tutorial-3.md
@@ -30,7 +30,7 @@ vmName=TutorialVM1
 az vm create \
   --resource-group $resourceGroup \
   --name $vmName \
-  --image UbuntuLTS \
+  --image Ubuntu2204 \
   --vnet-name $vnetName \
   --subnet $subnetName \
   --generate-ssh-keys \


### PR DESCRIPTION
The image in the example gives the error: 

Invalid image "UbuntuLTS". Use a valid image URN, custom image name, custom image id, VHD blob URI, or pick an image from ['CentOS85Gen2', 'Debian11', 'FlatcarLinuxFreeGen2', 'OpenSuseLeap154Gen2', 'RHELRaw8LVMGen2', 'SuseSles15SP3', 'Ubuntu2204', 'Win2022Datacenter', 'Win2022AzureEditionCore', 'Win2019Datacenter', 'Win2016Datacenter', 'Win2012R2Datacenter', 'Win2012Datacenter', 'Win2008R2SP1']. See vm create -h for more information on specifying an image.

Updated the image to Ubuntu2204 and this removes the error