### PR TITLE
Add instance discovery to 2.54.0 history notes

### DIFF
--- a/docs-ref-conceptual/release-notes-azure-cli.md
+++ b/docs-ref-conceptual/release-notes-azure-cli.md
@@ -123,6 +123,10 @@ Version 2.54.0
 * `az containerapp compose create`: Fix containerapp invalid memory resource
 * `az containerapp job create`: Fix problem of parsing parameters `minExecutions` and `maxExecutions` from `--yaml`
 
+### Core
+
+* [PREVIEW] Support disabling instance discovery by running `az config set core.instance_discovery=false`
+
 ### Cosmos DB
 
 * `az cosmosdb create/update`: Add support for minimum allowed TLS version and burst capacity configuration


### PR DESCRIPTION
https://github.com/Azure/azure-cli/pull/27494 added a history note for instance discovery to Core: https://github.com/Azure/azure-cli/blob/dev/src/azure-cli-core/HISTORY.rst#2540

```md
[Core] [PREVIEW] Support disabling instance discovery by running `az config set core.instance_discovery=false`
```

But currently the release pipeline doesn't include core changes, so we have to manually copy them (similar to https://github.com/MicrosoftDocs/azure-docs-cli/pull/2815)
