### PR TITLE
Update use-cli-effectively | Add 64-bit windows path to H2:Work Behind a Proxy

### DIFF
--- a/docs-ref-conceptual/use-cli-effectively.md
+++ b/docs-ref-conceptual/use-cli-effectively.md
@@ -273,10 +273,11 @@ If you're using Azure CLI over a proxy server that uses self-signed certificates
 
 | OS                     | Default certificate authority bundle                                                                      |
 |----------------------- |-----------------------------------------------------------------------------------------------------------|
-| Windows                | `C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\Lib\site-packages\certifi\cacert.pem`                   |
+| Windows 32-bit         | `C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\Lib\site-packages\certifi\cacert.pem`                   |
+| Windows 64-bit         | `C:\Program Files\Microsoft SDKs\Azure\CLI2\Lib\site-packages\certifi\cacert.pem`                         |
 | Ubuntu/Debian Linux    | `/opt/az/lib/python<version>/site-packages/certifi/cacert.pem`                                            |
 | CentOS/RHEL/SUSE Linux | `/usr/lib64/az/lib/python<version>/site-packages/certifi/cacert.pem`                                      |
-| macOS                  | `/usr/local/Cellar/azure-cli/<cliversion>/libexec/lib/python<version>/site-packages/certifi/cacert.pem` |
+| macOS                  | `/usr/local/Cellar/azure-cli/<cliversion>/libexec/lib/python<version>/site-packages/certifi/cacert.pem`   |
 
 Append the proxy server's certificate to the CA bundle certificate file, or copy the contents to another certificate file.  Then set `REQUESTS_CA_BUNDLE` to the new file location. Here's an example:
 


### PR DESCRIPTION
This PR is in response to Issue #4055 