### PR TITLE
Remove python version in macOS doc

### DIFF
--- a/docs-ref-conceptual/install-azure-cli-macos.md
+++ b/docs-ref-conceptual/install-azure-cli-macos.md
@@ -32,10 +32,6 @@ You can install the Azure CLI on macOS by updating your brew repository informat
 brew update && brew install azure-cli
 ```
 
-> [!IMPORTANT]
->
-> The Azure CLI has a dependency on the Homebrew `python@3.10` package, and will install it.
-
 ## Troubleshooting
 
 If you encounter a problem when installing the CLI through Homebrew, here are some common errors. If you experience a problem not covered here, [file an issue on GitHub](https://github.com/Azure/azure-cli/issues).


### PR DESCRIPTION
Close https://github.com/MicrosoftDocs/azure-docs-cli/issues/4035
The Python version has no impact on the CLI functionality.
Omitting it from the documentation to prevent updates with each Python version change.