### PR TITLE
use deb822 format when using apt for installation

### DIFF
--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -47,7 +47,7 @@ If you prefer a step-by-step installation process, complete the following steps 
 
     ```bash
     sudo mkdir -p /etc/apt/keyrings
-    curl -sL https://packages.microsoft.com/keys/microsoft.asc |\
+    curl -sLS https://packages.microsoft.com/keys/microsoft.asc |
       sudo gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
     sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
     ```

--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -137,7 +137,7 @@ You can also use `apt-get upgrade` to update the CLI package. This command upgra
 3. If you aren't using other packages from Microsoft, remove the signing key:
 
     ```bash
-    sudo rm /usr/share/keyrings/microsoft.gpg
+    sudo rm /etc/apt/keyrings/microsoft.gpg
     ```
 
 4. Remove any unneeded packages:

--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -59,7 +59,7 @@ If you prefer a step-by-step installation process, complete the following steps 
     Suites: ${AZ_DIST}
     Components: main
     Architectures: $(dpkg --print-architecture)
-    Signed-by: /usr/share/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
+    Signed-by: /etc/apt/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
     ```
 
 4. Update repository information and install the `azure-cli` package:
@@ -198,7 +198,7 @@ URIs: https://packages.microsoft.com/repos/azure-cli/
 Suites: hera
 Components: main
 Architectures: amd64
-Signed-by: /usr/share/keyrings/microsoft-archive-keyring.gpg
+Signed-by: /etc/apt/keyrings/microsoft.gpg
 ```
 
 Modified file contents
@@ -209,7 +209,7 @@ URIs: https://packages.microsoft.com/repos/azure-cli/
 Suites: bionic
 Components: main
 Architectures: amd64
-Signed-by: /usr/share/keyrings/microsoft-archive-keyring.gpg
+Signed-by: /etc/apt/keyrings/microsoft.gpg
 ```
 
 ### Proxy blocks connection

--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -47,7 +47,7 @@ If you prefer a step-by-step installation process, complete the following steps 
 
     ```bash
     curl -fssL https://packages.microsoft.com/keys/microsoft.asc |\
-      gpg --dearmor -o /usr/share/keyrings/microsoft.gpg
+      gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
     ```
 
 3. <div id="set-release"/>Add the Azure CLI software repository:

--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -29,7 +29,7 @@ The easiest way to install the Azure CLI is through a script maintained by the A
 If you wish to inspect the contents of the script yourself before executing, download the script first using `curl` and inspect it in your favorite text editor.
 
 ```bash
-curl -fsSL https://aka.ms/InstallAzureCLIDeb | sudo bash
+curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 ```
 
 ### Option 2: Step-by-step installation instructions
@@ -40,15 +40,16 @@ If you prefer a step-by-step installation process, complete the following steps 
 
     ```bash
     sudo apt-get update
-    sudo apt-get install apt-transport-https ca-certificates curl gnupg2 lsb-release
+    sudo apt-get install apt-transport-https ca-certificates curl gnupg lsb-release
     ```
 
 2. Download and install the Microsoft signing key:
 
     ```bash
     sudo mkdir -p /etc/apt/keyrings
-    curl -fsSL https://packages.microsoft.com/keys/microsoft.asc |\
-      gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
+    curl -sL https://packages.microsoft.com/keys/microsoft.asc |\
+      sudo gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
+    sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
     ```
 
 3. <div id="set-release"/>Add the Azure CLI software repository:

--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -29,7 +29,7 @@ The easiest way to install the Azure CLI is through a script maintained by the A
 If you wish to inspect the contents of the script yourself before executing, download the script first using `curl` and inspect it in your favorite text editor.
 
 ```bash
-curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+curl -sSL https://aka.ms/InstallAzureCLIDeb | sudo bash
 ```
 
 ### Option 2: Step-by-step installation instructions
@@ -40,25 +40,26 @@ If you prefer a step-by-step installation process, complete the following steps 
 
     ```bash
     sudo apt-get update
-    sudo apt-get install ca-certificates curl apt-transport-https lsb-release gnupg
+    sudo apt-get install apt-transport-https ca-certificates curl gnupg2 lsb-release
     ```
 
 2. Download and install the Microsoft signing key:
 
     ```bash
-    sudo mkdir -p /etc/apt/keyrings
-    curl -sLS https://packages.microsoft.com/keys/microsoft.asc |
-        gpg --dearmor |
-        sudo tee /etc/apt/keyrings/microsoft.gpg > /dev/null
-    sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
+    curl -fssL https://packages.microsoft.com/keys/microsoft.asc |\
+      gpg --dearmor -o /usr/share/keyrings/microsoft.gpg
     ```
 
 3. <div id="set-release"/>Add the Azure CLI software repository:
 
     ```bash
     AZ_DIST=$(lsb_release -cs)
-    echo "deb [arch=`dpkg --print-architecture` signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $AZ_DIST main" |
-        sudo tee /etc/apt/sources.list.d/azure-cli.list
+    echo "Types: deb
+    URIs: https://packages.microsoft.com/repos/azure-cli/
+    Suites: ${AZ_DIST}
+    Components: main
+    Architectures: $(dpkg --print-architecture)
+    Signed-by: /usr/share/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
     ```
 
 4. Update repository information and install the `azure-cli` package:
@@ -88,7 +89,7 @@ Configure the `azure-cli` repository information as shown previously. Available 
     AZ_VER=2.51.0
 
     # Install a specific version
-    sudo apt-get install azure-cli=$AZ_VER-1~$AZ_DIST
+    sudo apt-get install azure-cli=${AZ_VER}-1~${AZ_DIST}
     ```
 
     To install a specific version without variables, replace the Azure CLI version and Linux distribution name shown:
@@ -130,13 +131,13 @@ You can also use `apt-get upgrade` to update the CLI package. This command upgra
 2. If you don't plan to reinstall the CLI, remove the Azure CLI repository information:
 
    ```bash
-   sudo rm /etc/apt/sources.list.d/azure-cli.list
+   sudo rm /etc/apt/sources.list.d/azure-cli.sources
    ```
 
 3. If you aren't using other packages from Microsoft, remove the signing key:
 
     ```bash
-    sudo rm /etc/apt/trusted.gpg.d/microsoft.gpg
+    sudo rm /usr/share/keyrings/microsoft.gpg
     ```
 
 4. Remove any unneeded packages:
@@ -187,18 +188,28 @@ AZ_REPO="bookworm"
 
 ### Elementary OS (EOS) fails to install the Azure CLI
 
-EOS fails to install the Azure CLI because `lsb_release` returns `HERA`, which is the EOS release name.  The solution is to fix the file `/etc/apt/sources.list.d/azure-cli.list` and change `hera main` to `bionic main`.
+EOS fails to install the Azure CLI because `lsb_release` returns `HERA`, which is the EOS release name.  The solution is to fix the file `/etc/apt/sources.list.d/azure-cli.sources` and change `Suites: hera` to `Suites: bionic`.
 
 Original file contents:
 
 ```
-deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ hera main
+Types: deb
+URIs: https://packages.microsoft.com/repos/azure-cli/
+Suites: hera
+Components: main
+Architectures: amd64
+Signed-by: /usr/share/keyrings/microsoft-archive-keyring.gpg
 ```
 
 Modified file contents
 
 ```
-deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ bionic main
+Types: deb
+URIs: https://packages.microsoft.com/repos/azure-cli/
+Suites: bionic
+Components: main
+Architectures: amd64
+Signed-by: /usr/share/keyrings/microsoft-archive-keyring.gpg
 ```
 
 ### Proxy blocks connection

--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -46,7 +46,8 @@ If you prefer a step-by-step installation process, complete the following steps 
 2. Download and install the Microsoft signing key:
 
     ```bash
-    curl -fssL https://packages.microsoft.com/keys/microsoft.asc |\
+    sudo mkdir -p /etc/apt/keyrings
+    curl -fsSL https://packages.microsoft.com/keys/microsoft.asc |\
       gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
     ```
 

--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -29,7 +29,7 @@ The easiest way to install the Azure CLI is through a script maintained by the A
 If you wish to inspect the contents of the script yourself before executing, download the script first using `curl` and inspect it in your favorite text editor.
 
 ```bash
-curl -sSL https://aka.ms/InstallAzureCLIDeb | sudo bash
+curl -fsSL https://aka.ms/InstallAzureCLIDeb | sudo bash
 ```
 
 ### Option 2: Step-by-step installation instructions


### PR DESCRIPTION
This PR:
- replaces the `One-Line-Style` format with the `deb822` format, which will be the default in Ubuntu 24.04. See eg https://discourse.ubuntu.com/t/spec-apt-deb822-sources-by-default/29333 and https://repolib.readthedocs.io/en/latest/deb822-format.html