### PR TITLE
Fix login with az cli

### DIFF
--- a/docs-ref-conceptual/azure-cli-sp-tutorial-3.md
+++ b/docs-ref-conceptual/azure-cli-sp-tutorial-3.md
@@ -105,7 +105,9 @@ az keyvault secret download --file /path/to/cert.pfx \
                             --vault-name VaultName \
                             --name CertName \
                             --encoding base64
-openssl pkcs12 -in cert.pfx -passin pass: -out cert.pem -nodes
+openssl pkcs12 -in cert.pfx -passin pass: -passout pass: -out cert.pem -nodes
+
+az login --service-principal -u "$AppClientId" -p cert.pem --tenant "$TenantId"
 ```
 
 ## Convert an existing PKCS12 file
@@ -113,7 +115,7 @@ openssl pkcs12 -in cert.pfx -passin pass: -out cert.pem -nodes
 If you already have a PKCS#12 file, you can convert it to PEM format using OpenSSL. If you have a password, change the `passin` argument.
 
 ```console
-openssl pkcs12 -in fileName.p12 -clcerts -nodes -out fileName.pem -passin pass:
+openssl pkcs12 -in fileName.p12 -clcerts -nodes -out fileName.pem -passin pass: -passout pass:
 ```
 
 ## Append a certificate to a service principal


### PR DESCRIPTION
az cli required the PEM Private Key to be encrypted. When downloaded from Keyvault, the key is not password protected. This PR provides the fix.

More context > https://github.com/Azure/azure-cli/issues/7489#issuecomment-1959439989