### PR TITLE
Update .openpublishing.publish.config.json

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -56,6 +56,12 @@
       "url": "https://github.com/MicrosoftDocs/reusable-content",
       "branch": "main",
       "branch_mapping": {}
+    },
+    {
+      "path_to_root": "azure_cli_scripts",
+      "url": "https://github.com/Azure-Samples/azure-cli-samples",
+      "branch": "master",
+      "branch_mapping": {}
     }
   ],
   "branch_target_mapping": {


### PR DESCRIPTION
The purpose of this PR is to add AzureSamples/azure-cli-samples to depedent_repositores. Until this is committed to the main branch, dependent PRs cannot read in sample scripts for PR review.