### PR TITLE
Surround name with double quotes in group delete command

### DIFF
--- a/docs-ref-conceptual/get-started-tutorial-4-delete-resources.md
+++ b/docs-ref-conceptual/get-started-tutorial-4-delete-resources.md
@@ -28,7 +28,7 @@ Using random IDs and running these tutorial steps creates test resource groups t
 az group list --output table
 
 # Delete a resource group and do not wait for the operation to finish
-az group delete --name <msdocs-tutorial-rg-0000000> --no-wait
+az group delete --name "msdocs-tutorial-rg-0000000" --no-wait
 ```
 
 > [!TIP]


### PR DESCRIPTION
In my zsh terminal, the original command 

% az group delete --name <msdocs-tutorial-rg-00000000> --no-wait

gives this error

zsh: no such file or directory: msdocs-tutorial-rg-00000000

while the command

% az group delete --name "msdocs-tutorial-rg-00000000" --no-wait

gives the confirmation prompt as indicated by the tip

Are you sure you want to perform this operation? (y/n): y