### PR TITLE
Add bash example and label batch example correctly

### DIFF
--- a/docs-ref-conceptual/use-azure-cli-successfully.md
+++ b/docs-ref-conceptual/use-azure-cli-successfully.md
@@ -373,6 +373,18 @@ Use these scripts to save IDs to variables:
 
 ### [Bash](#tab/bash2)
 
+```bash
+#!/bin/bash
+
+# Loop through the VM IDs and stop each VM
+az vm list --resource-group VMResources --show-details --query "[?powerState=='VM running'].id" --output tsv | while read -r vm_id; do
+    echo "Stopping $vm_id"
+    az vm stop --ids "$vm_id"
+done
+```
+
+### [Batch](#tab/batch2)
+
 ```console
 ECHO OFF
 SETLOCAL

--- a/docs-ref-conceptual/use-azure-cli-successfully.md
+++ b/docs-ref-conceptual/use-azure-cli-successfully.md
@@ -383,7 +383,7 @@ az vm list --resource-group VMResources --show-details --query "[?powerState=='V
 done
 ```
 
-### [Cmd](#tab/cmd)
+### [Cmd](#tab/cmd2)
 
 ```azurecli
 ECHO OFF
@@ -407,8 +407,20 @@ az vm stop --ids $vm_ids # CLI stops all VMs in parallel
 
 Use these scripts to loop through a list:
 
-### [Bash](#tab/bash2)
+### [Bash](#tab/bash3)
 
+```bash
+#!/bin/bash
+
+# Loop through the VM IDs and stop each VM
+az vm list --resource-group VMResources --show-details --query "[?powerState=='VM running'].id" --output tsv | while read -r vm_id; do
+    echo "Stopping $vm_id"
+    az vm stop --ids "$vm_id"
+done
+```
+
+
+### [Cmd](#tab/cmd3)
 ```console
 ECHO OFF
 SETLOCAL
@@ -420,7 +432,7 @@ FOR /F "tokens=* USEBACKQ" %%F IN (
 )
 ```
 
-### [PowerShell](#tab/powershell2)
+### [PowerShell](#tab/powershell3)
 
 ```powershell
 $vm_ids=(az vm list --resource-group VMResources --show-details --query "[?powerState=='VM running'].id" --output tsv)

--- a/docs-ref-conceptual/use-azure-cli-successfully.md
+++ b/docs-ref-conceptual/use-azure-cli-successfully.md
@@ -374,13 +374,8 @@ Use these scripts to save IDs to variables:
 ### [Bash](#tab/bash2)
 
 ```bash
-#!/bin/bash
-
-# Loop through the VM IDs and stop each VM
-az vm list --resource-group VMResources --show-details --query "[?powerState=='VM running'].id" --output tsv | while read -r vm_id; do
-    echo "Stopping $vm_id"
-    az vm stop --ids "$vm_id"
-done
+vm_ids=$(az vm list --resource-group VMResources --show-details --query "[?powerState=='VM running'].id" --output tsv)
+az vm stop --ids $vm_ids # CLI stops all VMs in parallel
 ```
 
 ### [Cmd](#tab/cmd2)

--- a/docs-ref-conceptual/use-azure-cli-successfully.md
+++ b/docs-ref-conceptual/use-azure-cli-successfully.md
@@ -383,9 +383,9 @@ az vm list --resource-group VMResources --show-details --query "[?powerState=='V
 done
 ```
 
-### [Batch](#tab/batch2)
+### [Cmd](#tab/cmd)
 
-```console
+```azurecli
 ECHO OFF
 SETLOCAL
 FOR /F "tokens=* USEBACKQ" %%F IN (


### PR DESCRIPTION
The example labelled "bash" was actually a batch file.

Added a bash example, and re-labelled the batch file.