### PR TITLE
Add core.login_experience_v2 to our config doc

### DIFF
--- a/docs-ref-conceptual/azure-cli-configuration.md
+++ b/docs-ref-conceptual/azure-cli-configuration.md
@@ -103,6 +103,7 @@ When you provide a default value, that argument is no longer required by any com
 | | collect\_telemetry | boolean | Allow Microsoft to collect anonymous data on the usage of the CLI. For privacy information, see the [Azure CLI MIT license](https://github.com/Azure/azure-cli/blob/dev/LICENSE). |
 | | only\_show\_errors | boolean | Only show errors during command invocation. In other words, only errors are written to `stderr`. It suppresses warnings from preview, deprecated and experimental commands. It's also available for individual commands with the `--only-show-errors` parameter. |
 | | enable\_broker\_on\_windows | boolean | Use Web Account Manager (WAM) to authenticate to Azure through the `az login` command. |
+| | login\_experience\_v2 | boolean | Turn the `az login` subscription selector on/off. |
 | | no\_color | boolean | Disable color. Originally colored messages are prefixed with `DEBUG`, `INFO`, `WARNING` and `ERROR`. This boolean bypasses the issue of a third-party library where the terminal's color can't revert back after a `stdout` redirection. |
 | __clients__ | show_secrets_warning | boolean | Turn the warning for sensitive information output on/off. |
 | __logging__ | enable\_log\_file | boolean | Turn logging on/off. |


### PR DESCRIPTION
The purpose of this PR is to add the new `core.login_experience_v2` config setting to our config doc.