### PR TITLE
Fix tab names to match code

### DIFF
--- a/docs-ref-conceptual/use-azure-cli-successfully.md
+++ b/docs-ref-conceptual/use-azure-cli-successfully.md
@@ -371,7 +371,7 @@ Here are examples for using variables and looping through a list when working wi
 
 Use these scripts to save IDs to variables:
 
-### [Bash](#tab/bash2)
+### [Cmd](#tab/cmd2)
 
 ```azurecli
 ECHO OFF
@@ -395,7 +395,7 @@ az vm stop --ids $vm_ids # CLI stops all VMs in parallel
 
 Use these scripts to loop through a list:
 
-### [Bash](#tab/bash2)
+### [Cmd](#tab/cmd2)
 
 ```azurecli
 ECHO OFF


### PR DESCRIPTION
The tabs containing Windows Command Prompt code were incorrectly labelled "Bash"