### PR TITLE
removed deprecated ms.metadata lines and incorrect authors

### DIFF
--- a/docs-ref-conceptual/authenticate-azure-cli-interactively.md
+++ b/docs-ref-conceptual/authenticate-azure-cli-interactively.md
@@ -3,7 +3,6 @@ title: Sign in with Azure CLI at a command line | Microsoft Docs
 description: Learn how to sign into the Azure CLI interactively using az login, WAM, a web browser and a subscription selector.
 author: jiasli
 ms.author: jiasli
-manager: yonzhan
 ms.date: 05/21/2024
 ms.topic: conceptual
 ms.service: azure-cli

--- a/docs-ref-conceptual/authenticate-azure-cli-managed-identity.md
+++ b/docs-ref-conceptual/authenticate-azure-cli-managed-identity.md
@@ -3,7 +3,6 @@ title: Sign in with Azure CLI using a managed identity | Microsoft Docs
 description: Learn how to sign into the Azure CLI with managed identity.
 author: jiasli
 ms.author: jiasli
-manager: yonzhan
 ms.date: 09/22/2023
 ms.topic: conceptual
 ms.service: azure-cli

--- a/docs-ref-conceptual/authenticate-azure-cli-service-principal.md
+++ b/docs-ref-conceptual/authenticate-azure-cli-service-principal.md
@@ -3,7 +3,6 @@ title: Sign in with Azure CLI using a service principal | Microsoft Docs
 description: Learn how to sign into the Azure CLI using a service principal.
 author: jiasli
 ms.author: jiasli
-manager: yonzhan
 ms.date: 09/22/2023
 ms.topic: conceptual
 ms.service: azure-cli

--- a/docs-ref-conceptual/authenticate-azure-cli.md
+++ b/docs-ref-conceptual/authenticate-azure-cli.md
@@ -3,7 +3,6 @@ title: Sign in with Azure CLI — Login and Authentication | Microsoft Docs
 description: Learn the different authentication types for your Azure CLI login — sign in with Azure CLI automatically, locally, or interactively using the az login command.
 author: jiasli
 ms.author: jiasli
-manager: yonzhan
 ms.date: 05/21/2024
 ms.topic: conceptual
 ms.service: azure-cli

--- a/docs-ref-conceptual/azure-cli-configuration.md
+++ b/docs-ref-conceptual/azure-cli-configuration.md
@@ -3,7 +3,6 @@ title: Azure CLI configuration options | Microsoft Docs
 description: The Azure CLI allows user configuration for various settings. Manage values with the az configure command, environment variables, or in the configuration file.
 author: dbradish-microsoft
 ms.author: dbradish
-manager: barbkess
 ms.date: 08/2/2023 
 ms.topic: conceptual
 ms.service: azure-cli

--- a/docs-ref-conceptual/azure-cli-copilot.md
+++ b/docs-ref-conceptual/azure-cli-copilot.md
@@ -2,7 +2,6 @@
 title: Use Microsoft Copilot to learn Azure CLI | Microsoft Docs
 description: How to use the new AI functionalities of Microsoft Copilot to learn Azure CLI.
 ms.date: 04/05/2024
-manager: jasongroce
 author: daphnemamsft
 ms.author: daphnema
 ms.tool: azure-cli

--- a/docs-ref-conceptual/azure-cli-endpoints.md
+++ b/docs-ref-conceptual/azure-cli-endpoints.md
@@ -1,10 +1,8 @@
 --- 
 title: Endpoints used when installing the Azure CLI  | Microsoft Docs
 description: Learn what endpoints are used when installing the Azure CLI.  These URLs are sometimes added to allowlists when working behind a firewall.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
-ms.prod: non-product-specific
 ms.topic: conceptual
 ms.custom: devx-track-azurecli
 ms.date: 08/1/2023

--- a/docs-ref-conceptual/azure-cli-extension-alias.md
+++ b/docs-ref-conceptual/azure-cli-extension-alias.md
@@ -1,7 +1,6 @@
 ---
 title: Alias extension - Azure CLI | Microsoft Docs
 description: The alias extension allows users to define custom commands for the Azure CLI by using existing commands. Learn how to use the Azure CLI alias extension.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 09/15/2023

--- a/docs-ref-conceptual/azure-cli-extensions-overview.md
+++ b/docs-ref-conceptual/azure-cli-extensions-overview.md
@@ -1,7 +1,6 @@
 ---
 title: How to install and manage Azure CLI extensions | Microsoft Docs
 description: Learn how to find, install, uninstall, and manage extensions with Azure CLI. Use the Azure CLI to load extensions provided and maintained by Microsoft.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 08/2/2023

--- a/docs-ref-conceptual/azure-cli-global-parameters.md
+++ b/docs-ref-conceptual/azure-cli-global-parameters.md
@@ -1,7 +1,6 @@
 ---
 title: Use global parameters with Azure CLI  | Microsoft Docs
 description: Learn how to use various global parameters with Azure CLI to configure a resource group.
-manager: jasongroce
 author: daphnemamsft
 ms.author: daphnema
 ms.date: 08/2/2023

--- a/docs-ref-conceptual/azure-cli-learn-bash.md
+++ b/docs-ref-conceptual/azure-cli-learn-bash.md
@@ -1,10 +1,8 @@
 --- 
 title: How-to use the Azure CLI in a Bash environment | Microsoft Docs
 description: Learn how to use Bash with Azure CLI.  Query, format output, filter, use variables, and use Bash constructs of loops, if/exists/then and case statements.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
-ms.prod: non-product-specific
 ms.topic: sample
 ms.custom: devx-track-azurecli
 ms.date: 12/04/2023

--- a/docs-ref-conceptual/azure-cli-sp-tutorial-1.md
+++ b/docs-ref-conceptual/azure-cli-sp-tutorial-1.md
@@ -1,7 +1,6 @@
 ---
 title: Create Azure service principals using the Azure CLI | Microsoft Docs
 description: Learn how to create and use service principals to control access to Azure resources using the Azure CLI.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 10/10/2023

--- a/docs-ref-conceptual/azure-cli-sp-tutorial-2.md
+++ b/docs-ref-conceptual/azure-cli-sp-tutorial-2.md
@@ -1,7 +1,6 @@
 ---
 title: Create a service principal containing password authentication using the Azure CLI | Microsoft Docs
 description: Learn to use service principals with a password to control access to Azure resources.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 10/10/2023

--- a/docs-ref-conceptual/azure-cli-sp-tutorial-3.md
+++ b/docs-ref-conceptual/azure-cli-sp-tutorial-3.md
@@ -1,7 +1,6 @@
 ---
 title: Create a service principal containing a certificate using Azure CLI | Microsoft Docs
-description: Learn to use service principals with a self-signed certificate to control access to Azure resources.
-manager: jasongroce
+description: Learn to use service principals with a self-signed certificate to control access to Azure resources
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 10/10/2023

--- a/docs-ref-conceptual/azure-cli-sp-tutorial-4.md
+++ b/docs-ref-conceptual/azure-cli-sp-tutorial-4.md
@@ -1,7 +1,6 @@
 ---
 title: Get an existing service principal using the Azure CLI | Microsoft Docs
 description: Learn how to retrieve an existing service principal using the Azure CLI.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 10/10/2023

--- a/docs-ref-conceptual/azure-cli-sp-tutorial-5.md
+++ b/docs-ref-conceptual/azure-cli-sp-tutorial-5.md
@@ -1,7 +1,6 @@
 ---
 title: Manage service principal roles using the Azure CLI | Microsoft Docs
 description: Learn how to manage role assignments for a service principal using Azure CLI.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 10/10/2023

--- a/docs-ref-conceptual/azure-cli-sp-tutorial-6.md
+++ b/docs-ref-conceptual/azure-cli-sp-tutorial-6.md
@@ -1,7 +1,6 @@
 ---
 title: Create a resource using a service principal and the Azure CLI | Microsoft Docs
 description: Learn how to create a resource using a service principal and the Azure CLI.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 10/10/2023

--- a/docs-ref-conceptual/azure-cli-sp-tutorial-7.md
+++ b/docs-ref-conceptual/azure-cli-sp-tutorial-7.md
@@ -1,7 +1,6 @@
 ---
 title: Reset service principal credentials using the Azure CLI | Microsoft Docs
 description: Learn how to reset your service principal credentials using the Azure CLI.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 10/18/2023

--- a/docs-ref-conceptual/azure-cli-sp-tutorial-8.md
+++ b/docs-ref-conceptual/azure-cli-sp-tutorial-8.md
@@ -1,7 +1,6 @@
 ---
 title: Service principal cleanup and troubleshooting using Azure CLI | Microsoft Docs
 description: Learn how to cleanup and troubleshoot service principals.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 10/10/2023

--- a/docs-ref-conceptual/azure-cli-support-lifecycle.md
+++ b/docs-ref-conceptual/azure-cli-support-lifecycle.md
@@ -1,7 +1,6 @@
 ---
 title: Azure CLI lifecycle and support | Microsoft Docs
 description: Learn the details about the support lifecycle of the Azure CLI reference commands.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 05/21/2024

--- a/docs-ref-conceptual/azure-cli-variables.md
+++ b/docs-ref-conceptual/azure-cli-variables.md
@@ -1,7 +1,6 @@
 ---
 title: How to use variables in Azure CLI commands | Microsoft Docs
 description: Learn about specifying values directly in Azure CLI commands by using shell variables, setting a subscription, creating default values, or using persistent values.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.service: azure-cli

--- a/docs-ref-conceptual/azure-cli-vm-tutorial-1.md
+++ b/docs-ref-conceptual/azure-cli-vm-tutorial-1.md
@@ -2,7 +2,6 @@
 title: Create virtual machine (VM) on a virtual network (VNet) prerequisites – Azure CLI | Microsoft Docs
 description: Prerequisites for creating a virtual machines (VM) on a virtual network (VNet) with the Azure CLI.
 ms.date: 01/08/2024
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.tool: azure-cli

--- a/docs-ref-conceptual/azure-cli-vm-tutorial-2.md
+++ b/docs-ref-conceptual/azure-cli-vm-tutorial-2.md
@@ -2,7 +2,6 @@
 title: Create virtual network (VNet) – Azure CLI | Microsoft Docs
 description: Learn how to create a virtual network (VNet) and subnet with the Azure CLI.
 ms.date: 01/08/2024
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.tool: azure-cli

--- a/docs-ref-conceptual/azure-cli-vm-tutorial-3.md
+++ b/docs-ref-conceptual/azure-cli-vm-tutorial-3.md
@@ -2,7 +2,6 @@
 title: Create a virtual machines (VM) – Azure CLI | Microsoft Docs
 description: Learn how to create virtual machines (VM) connected to a virtual network (VNet) with the Azure CLI.
 ms.date: 01/08/2024
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.tool: azure-cli

--- a/docs-ref-conceptual/azure-cli-vm-tutorial-4.md
+++ b/docs-ref-conceptual/azure-cli-vm-tutorial-4.md
@@ -2,7 +2,6 @@
 title: Get virtual machines information with queries (VM) – Azure CLI | Microsoft Docs
 description: Learn how to get virtual machines (VM) information with Azure CLI queries.
 ms.date: 01/08/2024
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.tool: azure-cli

--- a/docs-ref-conceptual/azure-cli-vm-tutorial-5.md
+++ b/docs-ref-conceptual/azure-cli-vm-tutorial-5.md
@@ -2,7 +2,6 @@
 title: Set shell variables from CLI output – Azure CLI | Microsoft Docs
 description: Learn how to get virtual machines (VM) information and store results in an Azure CLI shell variable.
 ms.date: 01/08/2024
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.tool: azure-cli

--- a/docs-ref-conceptual/azure-cli-vm-tutorial-6.md
+++ b/docs-ref-conceptual/azure-cli-vm-tutorial-6.md
@@ -2,7 +2,6 @@
 title: Cleanup virtual machine resources (VM) – Azure CLI | Microsoft Docs
 description: Clean up resources used in the virtual machine tutorial.
 ms.date: 06/19/2023
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.tool: azure-cli

--- a/docs-ref-conceptual/azure-cli-vm-tutorial-7.md
+++ b/docs-ref-conceptual/azure-cli-vm-tutorial-7.md
@@ -2,7 +2,6 @@
 title: Summary of virtual machine resources (VM) – Azure CLI | Microsoft Docs
 description: Summary of what was taught in the virtual machine tutorial.
 ms.date: 08/2/2023
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.tool: azure-cli

--- a/docs-ref-conceptual/cheat-sheet-onboarding.md
+++ b/docs-ref-conceptual/cheat-sheet-onboarding.md
@@ -1,7 +1,6 @@
 ---
 title: Azure CLI onboarding cheat sheet | Microsoft Docs
 description: Quickly onboard with the Azure CLI. Get answers to common CLI questions and learn to use the Azure CLI.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 12/04/2023

--- a/docs-ref-conceptual/choose-the-right-azure-command-line-tool.md
+++ b/docs-ref-conceptual/choose-the-right-azure-command-line-tool.md
@@ -1,7 +1,6 @@
 ---
 title: Choose the right Azure command-line tool - Azure CLI | Microsoft Docs
 description: Learn which Azure command-line tool fits your needs with an Azure CLI vs Azure PowerShell comparison — get started with your preferred command-line tool.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.topic: quickstart

--- a/docs-ref-conceptual/command-line-tools-survey-guidance.md
+++ b/docs-ref-conceptual/command-line-tools-survey-guidance.md
@@ -1,7 +1,6 @@
 ---
 title: Azure command line tools survey guidance
 description: This article contains guidance about the Azure command line tools survey.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 06/19/2023

--- a/docs-ref-conceptual/create-azure-resources-at-scale.md
+++ b/docs-ref-conceptual/create-azure-resources-at-scale.md
@@ -1,7 +1,6 @@
 ---
 title: Create multiple resources from a script using Azure CLI
 description: Learn how to create multiple Azure resources from a script and log progress to a file. The Azure CLI script is provided for both Bash and PowerShell..
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 04/30/2024

--- a/docs-ref-conceptual/delete-azure-resources-at-scale.md
+++ b/docs-ref-conceptual/delete-azure-resources-at-scale.md
@@ -1,7 +1,6 @@
 ---
 title: Delete multiple resources from a script using Azure CLI
 description: Learn how to delete multiple Azure resources from a script and log progress to a file.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 04/30/2024

--- a/docs-ref-conceptual/format-output-azure-cli.md
+++ b/docs-ref-conceptual/format-output-azure-cli.md
@@ -1,7 +1,6 @@
 ---
 title: Output formats - Azure CLI | Microsoft Docs
 description: The Azure CLI offers various output formats such as JSON and YAML. Learn how to format the output of Azure CLI commands to tables, lists or json.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 01/29/2024

--- a/docs-ref-conceptual/get-started-tutorial-0-before-you-begin.md
+++ b/docs-ref-conceptual/get-started-tutorial-0-before-you-begin.md
@@ -1,7 +1,6 @@
 ---
 title: Learn about Azure CLI environments, terms, and compare the Azure CLI to Azure PowerShell | Microsoft Docs
 description: Learn the environments you can use to execute Azure CLI commands, Azure CLI terms, how the Azure CLI compares to Azure PowerShell.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 12/04/2023

--- a/docs-ref-conceptual/get-started-tutorial-1-prepare-environment.md
+++ b/docs-ref-conceptual/get-started-tutorial-1-prepare-environment.md
@@ -1,7 +1,6 @@
 ---
 title: Configure your Azure CLI environment | Microsoft Docs
 description: Learn Azure CLI installation, sign in, setting environment variables, and creating Azure resources containing a random ID.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 12/04/2023

--- a/docs-ref-conceptual/get-started-tutorial-2-environment-syntax.md
+++ b/docs-ref-conceptual/get-started-tutorial-2-environment-syntax.md
@@ -1,7 +1,6 @@
 ---
 title: Run Azure CLI commands with Bash, PowerShell Cmd syntax | Microsoft Docs
 description: Learn about quoting differences, line continuation and debugging in Bash, PowerShell and Windows Cmd environments.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 12/04/2023

--- a/docs-ref-conceptual/get-started-tutorial-3-use-variables.md
+++ b/docs-ref-conceptual/get-started-tutorial-3-use-variables.md
@@ -1,7 +1,6 @@
 ---
 title: Get variable values from Azure resources or a local JSON file | Microsoft Docs
 description: Learn how to use variables to store JSON file properties and query output.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 12/04/2023

--- a/docs-ref-conceptual/get-started-tutorial-4-delete-resources.md
+++ b/docs-ref-conceptual/get-started-tutorial-4-delete-resources.md
@@ -1,7 +1,6 @@
 ---
 title: Delete Azure resources using a script | Microsoft Docs
 description: Learn how to delete Azure resources at scale using a for-each loop
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 12/04/2023

--- a/docs-ref-conceptual/get-started-with-azure-cli.md
+++ b/docs-ref-conceptual/get-started-with-azure-cli.md
@@ -1,7 +1,6 @@
 ---
 title: Get started with Azure Command-Line Interface (CLI) | Microsoft Docs
 description: Learn how to start using the Azure CLI by completing common commands. You can begin using the Azure CLI by running it in an Azure Cloud Shell environment.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 03/07/2024

--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -1,7 +1,6 @@
 ---
-author: chasecrum
-ms.author: chasecrum
-manager: mamccrea
+author: dbradish-microsoft
+ms.author: dbradish
 ms.date: 09/27/2023
 ms.topic: include
 ms.custom: devx-track-azurecli, linux-related-content

--- a/docs-ref-conceptual/includes/cli-install-linux-dnf.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-dnf.md
@@ -1,7 +1,6 @@
 ---
 author: dbradish-microsoft
 ms.author: dbradish
-manager: mamccrea
 ms.date: 08/1/2023
 ms.topic: include
 ms.custom: devx-track-azurecli, linux-related-content

--- a/docs-ref-conceptual/includes/cli-install-linux-script.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-script.md
@@ -1,11 +1,9 @@
 ---
-author: chasecrum
-ms.author: chasecrum
-manager: mamccrea
+author: dbradish-microsoft
+ms.author: dbradish
 ms.date: 08/01/2023
 ms.topic: include
 ms.service: azure-cli
-ms.devlang: azurecli
 ms.custom: devx-track-azurecli
 ---
 

--- a/docs-ref-conceptual/includes/cli-install-linux-tdnf.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-tdnf.md
@@ -1,7 +1,6 @@
 ---
-author: chasecrum
-ms.author: chasecrum
-manager: mamccrea
+author: dbradish-microsoft
+ms.author: dbradish
 ms.date: 08/01/2023
 ms.topic: include
 ms.custom: devx-track-azurecli, linux-related-content

--- a/docs-ref-conceptual/includes/cli-install-linux-zypper.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-zypper.md
@@ -1,11 +1,9 @@
 ---
-author: chasecrum
-ms.author: chasecrum
-manager: rayoflores
+author: dbradish-microsoft
+ms.author: dbradish
 ms.date: 02/8/2024
 ms.topic: include
 ms.service: azure-cli
-ms.devlang: azurecli
 ms.custom: devx-track-azurecli, linux-related-content
 ---
 

--- a/docs-ref-conceptual/includes/specific-version.md
+++ b/docs-ref-conceptual/includes/specific-version.md
@@ -1,7 +1,6 @@
 ---
 author: dbradish-microsoft
 ms.author: dbradish
-manager: barbkess
 ms.date: 09/13/2023
 ms.topic: include
 ms.custom: devx-track-azurecli

--- a/docs-ref-conceptual/install-azure-cli-linux.md
+++ b/docs-ref-conceptual/install-azure-cli-linux.md
@@ -1,9 +1,8 @@
 ---
 title: Install the Azure CLI on Linux | Microsoft Docs
 description: Learn how to install and run the Azure CLI on Linux manually. You can install the Azure CLI on Linux computers with one command or a step-by-step process.
-author: chasecrum
-ms.author: chasecrum
-manager: mamccrea
+author: jiasli
+ms.author: jiasli
 ms.date: 08/2/2023
 ms.topic: conceptual
 ms.service: azure-cli

--- a/docs-ref-conceptual/install-azure-cli.md
+++ b/docs-ref-conceptual/install-azure-cli.md
@@ -3,7 +3,6 @@ title: How to install the Azure CLI | Microsoft Docs
 description: The Azure CLI is available to install in Windows, macOS and Linux environments. It can also be run in a Docker container and Azure Cloud Shell.
 author: dbradish-microsoft
 ms.author: dbradish
-manager: mamccrea
 ms.date: 09/28/2023
 ms.topic: conceptual
 ms.service: azure-cli

--- a/docs-ref-conceptual/install-classic-cli.md
+++ b/docs-ref-conceptual/install-classic-cli.md
@@ -3,7 +3,6 @@ title: Install the Azure classic CLI | Microsoft Docs
 description: Learn how to install the Azure classic CLI for macOS, Linux, and Windows to use open-source shell-based commands for managing Microsoft Azure services.
 author: jiasli
 ms.author: jiasli
-manager: yonzhan
 ms.date: 06/19/2023
 ms.topic: conceptual
 ms.service: azure-cli

--- a/docs-ref-conceptual/interactive-azure-cli.md
+++ b/docs-ref-conceptual/interactive-azure-cli.md
@@ -1,7 +1,6 @@
 ---
 title: Learn to use Azure CLI interactive mode | Microsoft Docs
 description: The Azure CLI interactive mode is an interactive shell with autocompletion, command descriptions, and examples. 
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 08/2/2023

--- a/docs-ref-conceptual/manage-azure-groups-azure-cli.md
+++ b/docs-ref-conceptual/manage-azure-groups-azure-cli.md
@@ -1,7 +1,6 @@
 ---
 title: How to manage Azure resource groups – Azure CLI | Microsoft Docs
 description: Learn how to manage Azure resource groups in the Azure CLI, a cross-platform tool to connect to Azure and execute administrative commands on Azure resources.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 08/2/2023

--- a/docs-ref-conceptual/manage-azure-subscriptions-azure-cli.md
+++ b/docs-ref-conceptual/manage-azure-subscriptions-azure-cli.md
@@ -1,7 +1,6 @@
 ---
 title: How to manage Azure subscriptions – Azure CLI | Microsoft Docs
 description: Learn about Azure tenants, users, and subscriptions. Use Azure CLI to manage your subscriptions, create management groups, and lock subscriptions.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 01/12/2024

--- a/docs-ref-conceptual/manage-clouds-azure-cli.md
+++ b/docs-ref-conceptual/manage-clouds-azure-cli.md
@@ -1,7 +1,6 @@
 ---
 title: Azure cloud management - Azure CLI | Microsoft Docs
 description: Create, sign in, and manage multiple clouds with the Azure CLI. Learn how to get information on clouds, change the current cloud, and register/unregister new clouds.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 06/19/2023

--- a/docs-ref-conceptual/microsoft-graph-migration.md
+++ b/docs-ref-conceptual/microsoft-graph-migration.md
@@ -3,11 +3,9 @@ title: Microsoft Graph migration | Microsoft Docs
 description: Learn about the Microsoft Graph migration of Azure CLI.
 author: jiasli
 ms.author: jiasli
-manager: yonzhan
 ms.date: 08/1/2023
 ms.topic: conceptual
 ms.service: azure-cli
-ms.devlang: azurecli
 ms.custom: devx-track-azurecli, seo-azure-cli
 keywords: microsoft graph, ms graph, active directory graph, ad graph, azure cli 
 ---

--- a/docs-ref-conceptual/msal-based-azure-cli.md
+++ b/docs-ref-conceptual/msal-based-azure-cli.md
@@ -3,7 +3,6 @@ title: MSAL-based Azure CLI | Microsoft Docs
 description: Learn about the MSAL-based Azure CLI.
 author: jiasli
 ms.author: jiasli
-manager: yonzhan
 ms.date: 08/1/2023
 ms.topic: conceptual
 ms.service: azure-cli

--- a/docs-ref-conceptual/query-azure-cli.md
+++ b/docs-ref-conceptual/query-azure-cli.md
@@ -1,7 +1,6 @@
 ---
 title: JMESPath query command results with Azure CLI | Microsoft Docs
 description: The Azure CLI uses the --query argument to execute a JMESPath query on the results of commands. Learn how to use the features of JMESPath in this article.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 08/2/2023

--- a/docs-ref-conceptual/reference-docs-index.md
+++ b/docs-ref-conceptual/reference-docs-index.md
@@ -2,7 +2,6 @@
 title: Azure CLI reference command article list | Microsoft Docs
 description: Find links to Azure CLI articles demonstrating the use of reference commands.  Search by reference group or command name.
 author: dbradish-microsoft
-manager: jasongroce
 ms.author: dbradish
 ms.date: 11/27/2023
 ms.service: azure-cli

--- a/docs-ref-conceptual/reference-types-and-status.md
+++ b/docs-ref-conceptual/reference-types-and-status.md
@@ -1,7 +1,6 @@
 ---
 title: Reference types, status and support levels – Azure CLI | Microsoft Docs
 description: Learn about the Azure CLI reference types, statuses and support levels
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 08/1/2023

--- a/docs-ref-conceptual/release-notes-azure-cli.md
+++ b/docs-ref-conceptual/release-notes-azure-cli.md
@@ -154,7 +154,7 @@ Version 2.60.0
 * `az aks create/update`: Prompt warning during disablement about CR deletion
 * `az aks create/update`: Udpate RP registration code to work on azure monitor subscription
 * `az aks create/update`: Update to add default region for workspace creation in air gapped cloud
-* `az aks nodepool add`: Add parameter `--disable-windows-outbound-nat` to add a Windows agent pool which the Windows OutboundNAT is disabled
+* `az aks nodepool add`: Add parameter `--disable-windows-outbound-nat` to add a Windows agent pool which the Windows OutboundNAT is disabled
 
 ### App Service
 
@@ -984,7 +984,7 @@ Version 2.53.0
 ### Backup
 
 * `az backup backup-properties`: Add option for setting `--soft-delete-feature-state` to "AlwaysOn", and `--soft-delete-duration` with values between 14 to 180 (inclusive)
-* `az backup vault list-soft-deleted-containers`: List all soft-deleted containers in a backup vault
+* `az backup vault list-soft-deleted-containers`: List all soft-deleted containers in a backup vault
 
 ### Compute
 
@@ -1795,7 +1795,7 @@ Version 2.46.0
 * [BREAKING CHANGE] `az network watcher connection-monitor endpoint add`: Remove deprecated parameters `filter-item` and `filter-type`
 * `az network nsg rule list`: Fix `-o table` cannot be used
 * `az network private-endpoint-connection`: Add provider `Microsoft.Monitor/Accounts`
-* `az network express-route gateway connection create/update`: Add parameters `--inbound-route-map` and `--outbound-route-map` to support route map
+* `az network express-route gateway connection create/update`: Add parameters `--inbound-route-map` and `--outbound-route-map` to support route map
 * Fix #25408: `az network application-gateway rule create`: Creation fails with `--redirect-config` when there are multiple pools
 * `az network private-endpoint-connection`: Add provider `Microsoft.DBforMySQL/flexibleServers`
 
@@ -4230,7 +4230,7 @@ Version 2.28.0
 * Upgrade api-version for VM and VMSS from `2021-03-01` to `2021-04-01`
 * `az vmss create/update`: Support spot restore policy to VM scale sets
 * Add new examples for creating disk from share image gallery
-* `az vm image​ list/list-offers/list-skus/list-publishers/show`: Add new parameter ​`--edge-zone`​ to support querying the image under edge zone
+* `az vm image​ list/list-offers/list-skus/list-publishers/show`: Add new parameter ​`--edge-zone`​ to support querying the image under edge zone
 * Fix the issue caused by the lack of `os_type` when creating VM from shared gallery id
 * Update shared image gallery doc
 * `az capacity reservation`: Add new commands to manage capacity reservation

--- a/docs-ref-conceptual/release-notes-azure-cli.md
+++ b/docs-ref-conceptual/release-notes-azure-cli.md
@@ -154,7 +154,7 @@ Version 2.60.0
 * `az aks create/update`: Prompt warning during disablement about CR deletion
 * `az aks create/update`: Udpate RP registration code to work on azure monitor subscription
 * `az aks create/update`: Update to add default region for workspace creation in air gapped cloud
-* `az aks nodepool add`: Add parameter `--disable-windows-outbound-nat` to add a Windows agent pool which the Windows OutboundNAT is disabled
+* `az aks nodepool add`: Add parameter `--disable-windows-outbound-nat` to add a Windows agent pool which the Windows OutboundNAT is disabled
 
 ### App Service
 
@@ -984,7 +984,7 @@ Version 2.53.0
 ### Backup
 
 * `az backup backup-properties`: Add option for setting `--soft-delete-feature-state` to "AlwaysOn", and `--soft-delete-duration` with values between 14 to 180 (inclusive)
-* `az backup vault list-soft-deleted-containers`: List all soft-deleted containers in a backup vault
+* `az backup vault list-soft-deleted-containers`: List all soft-deleted containers in a backup vault
 
 ### Compute
 
@@ -1795,7 +1795,7 @@ Version 2.46.0
 * [BREAKING CHANGE] `az network watcher connection-monitor endpoint add`: Remove deprecated parameters `filter-item` and `filter-type`
 * `az network nsg rule list`: Fix `-o table` cannot be used
 * `az network private-endpoint-connection`: Add provider `Microsoft.Monitor/Accounts`
-* `az network express-route gateway connection create/update`: Add parameters `--inbound-route-map` and `--outbound-route-map` to support route map
+* `az network express-route gateway connection create/update`: Add parameters `--inbound-route-map` and `--outbound-route-map` to support route map
 * Fix #25408: `az network application-gateway rule create`: Creation fails with `--redirect-config` when there are multiple pools
 * `az network private-endpoint-connection`: Add provider `Microsoft.DBforMySQL/flexibleServers`
 
@@ -4230,7 +4230,7 @@ Version 2.28.0
 * Upgrade api-version for VM and VMSS from `2021-03-01` to `2021-04-01`
 * `az vmss create/update`: Support spot restore policy to VM scale sets
 * Add new examples for creating disk from share image gallery
-* `az vm image​ list/list-offers/list-skus/list-publishers/show`: Add new parameter ​`--edge-zone`​ to support querying the image under edge zone
+* `az vm image​ list/list-offers/list-skus/list-publishers/show`: Add new parameter ​`--edge-zone`​ to support querying the image under edge zone
 * Fix the issue caused by the lack of `os_type` when creating VM from shared gallery id
 * Update shared image gallery doc
 * `az capacity reservation`: Add new commands to manage capacity reservation

--- a/docs-ref-conceptual/run-azure-cli-docker.md
+++ b/docs-ref-conceptual/run-azure-cli-docker.md
@@ -3,7 +3,6 @@ title: How to run Azure CLI in a Docker Container | Microsoft Docs
 description: Learn how to run a Docker container hosting the Azure CLI. Docker gets you started quickly with an isolated environment in which to run the Azure CLI.
 author: jiasli
 ms.author: jiasli
-manager: yonzhan
 ms.date: 03/14/2024
 ms.topic: conceptual
 ms.service: azure-cli

--- a/docs-ref-conceptual/samples-index.md
+++ b/docs-ref-conceptual/samples-index.md
@@ -2,9 +2,8 @@
 title: Azure CLI samples full list | Microsoft Docs
 description: Find links to Azure CLI samples.  Search by Azure service, command name, or GitHub file name.
 author: dbradish-microsoft
-manager: jasongroce
 ms.author: dbradish
-ms.date: 11/27/2023
+ms.date: 06/01/2024
 ms.service: azure-cli
 ms.tool: azure-cli
 ms.topic: sample 

--- a/docs-ref-conceptual/update-azure-cli.md
+++ b/docs-ref-conceptual/update-azure-cli.md
@@ -3,7 +3,6 @@ title: How to update the Azure CLI | Microsoft Docs
 description: Learn how to update the Azure Command-Line Interface (CLI) by performing a manual update or enabling autoupgrade for the CLI.
 author: jiasli
 ms.author: jiasli
-manager: yonzhan
 ms.date: 08/1/2023
 ms.topic: conceptual
 ms.service: azure-cli

--- a/docs-ref-conceptual/use-azure-cli-rest-command.md
+++ b/docs-ref-conceptual/use-azure-cli-rest-command.md
@@ -1,7 +1,6 @@
 ---
 title: Learn how to use the Azure REST API with Azure CLI| Microsoft Docs
 description: Learn how to use Azure rest with Azure Command Line (CLI). 
-manager: jasongroce
 author: daphnemamsft
 ms.author: daphnema
 ms.date: 01/31/2024

--- a/docs-ref-conceptual/use-azure-cli-successfully-in-powershell.md
+++ b/docs-ref-conceptual/use-azure-cli-successfully-in-powershell.md
@@ -1,7 +1,6 @@
 ---
 title: Tips to use the Azure CLI successfully in a PowerShell environment | Microsoft Docs
 description: Learn how to format Azure CLI parameters for a PowerShell environment.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.topic: quickstart

--- a/docs-ref-conceptual/use-azure-cli-successfully.md
+++ b/docs-ref-conceptual/use-azure-cli-successfully.md
@@ -1,9 +1,8 @@
 ---
 title: Tips for using the Azure CLI | Microsoft Docs
 description: Learn tips for using Azure CLI successfully, such as output formats, passing parameter values, and quoting rules for different shells.
-manager: jasongroce
-author: dbradish-microsoft
-ms.author: dbradish
+author: jiasli
+ms.author: jiasli
 ms.date: 12/04/2023
 ms.topic: conceptual
 ms.service: azure-cli

--- a/docs-ref-conceptual/what-is-azure-cli.md
+++ b/docs-ref-conceptual/what-is-azure-cli.md
@@ -1,7 +1,6 @@
 ---
 title: What is the Azure CLI? | Microsoft Docs
 description: The Azure Command-Line Interface (CLI) is a command-line tool designed to create and manage Azure resources available in Windows, macOS, Linux, and Docker containers.
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 03/07/2024

--- a/docs-ref-conceptual/whats-new-overview.md
+++ b/docs-ref-conceptual/whats-new-overview.md
@@ -1,7 +1,6 @@
 ---
 title: What's new in Azure Command-Line Interface (CLI) | Microsoft Docs
 description: Learn what's new in the Azure CLI
-manager: jasongroce
 author: dbradish-microsoft
 ms.author: dbradish
 ms.date: 05/21/2024


### PR DESCRIPTION
The purpose of this PR is to clean up metadata
1. `chasecrum` is no longer with MSFT
2. `ms.prod`, `ms.devlang`, and `manager` have been deprecated

Release notes and extension list are autogenerated and were not updated.