### PR TITLE
docfx | add ms.service and remove devlang

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -207,7 +207,6 @@
     "globalMetadata": {
       "brand": "azure",
       "breadcrumb_path": "/cli/azure/breadcrumb/toc.json",
-      "devlang": "azurecli",
       "feedback_system": "OpenSource",
       "feedback_product_url": "https://github.com/Azure/azure-cli/issues/new/choose",
       "feedback_help_link_url": "https://techcommunity.microsoft.com/t5/azure/ct-p/Azure",
@@ -222,8 +221,9 @@
       "keywords": "azure, cli, command line",
       "author": "dbradish-microsoft",
       "ms.author": "dbradish",
-      "ms.date": "08/11/2023",
+      "ms.date": "05/21/2024",
       "ms.devlang": "azurecli",
+      "ms.service": "azure-cli",
       "ms.topic": "reference",
       "searchScope": [ "Azure", "Azure CLI" ],
       "showPowerShellPicker": "true",


### PR DESCRIPTION
`devlang` is not a valid metadata tag.  we already have `ms.devlang` which is correct.
`ms.service` was missing from file