### PR TITLE
removed /en-us/ from autogen reference content

### DIFF
--- a/2020-09-01-hybrid/docs-ref-autogen/aks.yml
+++ b/2020-09-01-hybrid/docs-ref-autogen/aks.yml
@@ -2061,7 +2061,7 @@ directCommands:
             * Has a digit
             * Has a special character (Regex match [\W_])
           - Disallowed values:  "abc@123", "P@$$w0rd", "P@ssw0rd", "P@ssword123", "Pa$$word", "pass@word1", "Password!", "Password1", "Password22", "iloveyou!"
-      Reference: https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.management.compute.models.virtualmachinescalesetosprofile.adminpassword?view=azure-dotnet.
+      Reference: https://docs.microsoft.com/dotnet/api/microsoft.azure.management.compute.models.virtualmachinescalesetosprofile.adminpassword?view=azure-dotnet.
   - name: --windows-admin-username
     summary: |-
       User account to create on windows node VMs.
@@ -2071,7 +2071,7 @@ directCommands:
           - Disallowed values: "administrator", "admin", "user", "user1", "test", "user2", "test1", "user3", "admin1", "1", "123", "a", "actuser", "adm", "admin2", "aspnet", "backup", "console", "david", "guest", "john", "owner", "root", "server", "sql", "support", "support_388945a0", "sys", "test2", "test3", "user4", "user5".
           - Minimum-length: 1 character
           - Max-length: 20 characters
-      Reference: https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.management.compute.models.virtualmachinescalesetosprofile.adminusername?view=azure-dotnet.
+      Reference: https://docs.microsoft.com/dotnet/api/microsoft.azure.management.compute.models.virtualmachinescalesetosprofile.adminusername?view=azure-dotnet.
   - name: --workload-runtime
     defaultValue: "OCIContainer"
     parameterValueGroup: "KataCcIsolation, KataMshvVmIsolation, OCIContainer, WasmWasi"
@@ -4738,7 +4738,7 @@ directCommands:
             * Has a digit
             * Has a special character (Regex match [\W_])
           - Disallowed values:  "abc@123", "P@$$w0rd", "P@ssw0rd", "P@ssword123", "Pa$$word", "pass@word1", "Password!", "Password1", "Password22", "iloveyou!"
-      Reference: https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.management.compute.models.virtualmachinescalesetosprofile.adminpassword?view=azure-dotnet.
+      Reference: https://docs.microsoft.com/dotnet/api/microsoft.azure.management.compute.models.virtualmachinescalesetosprofile.adminpassword?view=azure-dotnet.
   - name: --yes -y
     defaultValue: "False"
     summary: |-

--- a/2020-09-01-hybrid/docs-ref-autogen/appconfig/kv.yml
+++ b/2020-09-01-hybrid/docs-ref-autogen/appconfig/kv.yml
@@ -159,7 +159,7 @@ directCommands:
     defaultValue: "False"
     parameterValueGroup: "false, true"
     summary: |-
-      Export key-values as App Configuration references. For more information, see https://docs.microsoft.com/en-us/azure/app-service/app-service-configuration-references.
+      Export key-values as App Configuration references. For more information, see https://docs.microsoft.com/azure/app-service/app-service-configuration-references.
   - name: --format
     parameterValueGroup: "json, properties, yaml"
     summary: |-

--- a/2020-09-01-hybrid/docs-ref-autogen/devops.yml
+++ b/2020-09-01-hybrid/docs-ref-autogen/devops.yml
@@ -50,7 +50,7 @@ directCommands:
 - uid: az_devops_invoke
   name: az devops invoke
   summary: |-
-    This command will invoke request for any DevOps area and resource. Please use only json output as the response of this command is not fixed. Helpful docs - https://docs.microsoft.com/en-us/rest/api/azure/devops/.
+    This command will invoke request for any DevOps area and resource. Please use only json output as the response of this command is not fixed. Helpful docs - https://docs.microsoft.com/rest/api/azure/devops/.
   status: GA
   sourceType: Extension
   syntax: >-

--- a/2020-09-01-hybrid/docs-ref-autogen/dt/twin.yml
+++ b/2020-09-01-hybrid/docs-ref-autogen/dt/twin.yml
@@ -144,7 +144,7 @@ directCommands:
   summary: |-
     Query the digital twins of an instance. Allows traversing relationships and filtering by property values.
   description: |-
-    In many twin queries, the `$` character is used to reference the `$dtId` property of a twin. In bash-like shells or powershell the `$` character has functional meaning and must be escaped as part of the query input. Please review the Digital Twins CLI concepts document https://docs.microsoft.com/en-us/azure/digital-twins/concepts-cli for more information.
+    In many twin queries, the `$` character is used to reference the `$dtId` property of a twin. In bash-like shells or powershell the `$` character has functional meaning and must be escaped as part of the query input. Please review the Digital Twins CLI concepts document https://docs.microsoft.com/azure/digital-twins/concepts-cli for more information.
   status: GA
   sourceType: Extension
   syntax: >-

--- a/2020-09-01-hybrid/docs-ref-autogen/load/test-run/server-metric.yml
+++ b/2020-09-01-hybrid/docs-ref-autogen/load/test-run/server-metric.yml
@@ -56,7 +56,7 @@ directCommands:
   - isRequired: true
     name: --metric-id
     summary: |-
-      Fully qualified ID of the server metric. Refer https://docs.microsoft.com/en-us/rest/api/monitor/metric-definitions/list#metricdefinition.
+      Fully qualified ID of the server metric. Refer https://docs.microsoft.com/rest/api/monitor/metric-definitions/list#metricdefinition.
   - isRequired: true
     name: --metric-name
     summary: |-
@@ -128,7 +128,7 @@ directCommands:
   - isRequired: true
     name: --metric-id
     summary: |-
-      Fully qualified ID of the server metric. Refer https://docs.microsoft.com/en-us/rest/api/monitor/metric-definitions/list#metricdefinition.
+      Fully qualified ID of the server metric. Refer https://docs.microsoft.com/rest/api/monitor/metric-definitions/list#metricdefinition.
   - isRequired: true
     name: --test-run-id -r
     summary: |-

--- a/2020-09-01-hybrid/docs-ref-autogen/load/test/server-metric.yml
+++ b/2020-09-01-hybrid/docs-ref-autogen/load/test/server-metric.yml
@@ -56,7 +56,7 @@ directCommands:
   - isRequired: true
     name: --metric-id
     summary: |-
-      Fully qualified ID of the server metric. Refer https://docs.microsoft.com/en-us/rest/api/monitor/metric-definitions/list#metricdefinition.
+      Fully qualified ID of the server metric. Refer https://docs.microsoft.com/rest/api/monitor/metric-definitions/list#metricdefinition.
   - isRequired: true
     name: --metric-name
     summary: |-
@@ -128,7 +128,7 @@ directCommands:
   - isRequired: true
     name: --metric-id
     summary: |-
-      Fully qualified ID of the server metric. Refer https://docs.microsoft.com/en-us/rest/api/monitor/metric-definitions/list#metricdefinition.
+      Fully qualified ID of the server metric. Refer https://docs.microsoft.com/rest/api/monitor/metric-definitions/list#metricdefinition.
   - isRequired: true
     name: --test-id -t
     summary: |-

--- a/2020-09-01-hybrid/docs-ref-autogen/managed-cassandra.yml
+++ b/2020-09-01-hybrid/docs-ref-autogen/managed-cassandra.yml
@@ -8,7 +8,7 @@ extensionInformation: >-
 summary: |-
   Azure Managed Cassandra.
 description: |-
-  See https://docs.microsoft.com/en-us/azure/managed-instance-apache-cassandra/manage-resources-cli for Cassandra API samples.
+  See https://docs.microsoft.com/azure/managed-instance-apache-cassandra/manage-resources-cli for Cassandra API samples.
 status: GA
 sourceType: Extension
 commands:
@@ -53,4 +53,4 @@ globalParameters:
   summary: |-
     Increase logging verbosity. Use --debug for full debug logs.
 metadata:
-  description: See https://docs.microsoft.com/en-us/azure/managed-instance-apache-cassandra/manage-resources-cli for Cassandra API samples.
+  description: See https://docs.microsoft.com/azure/managed-instance-apache-cassandra/manage-resources-cli for Cassandra API samples.

--- a/2020-09-01-hybrid/docs-ref-autogen/managed-cassandra/cluster.yml
+++ b/2020-09-01-hybrid/docs-ref-autogen/managed-cassandra/cluster.yml
@@ -8,7 +8,7 @@ extensionInformation: >-
 summary: |-
   Azure Managed Cassandra Cluster.
 description: |-
-  See https://docs.microsoft.com/en-us/azure/managed-instance-apache-cassandra/manage-resources-cli for Cassandra API samples.
+  See https://docs.microsoft.com/azure/managed-instance-apache-cassandra/manage-resources-cli for Cassandra API samples.
 status: GA
 sourceType: Extension
 directCommands:
@@ -346,4 +346,4 @@ globalParameters:
   summary: |-
     Increase logging verbosity. Use --debug for full debug logs.
 metadata:
-  description: See https://docs.microsoft.com/en-us/azure/managed-instance-apache-cassandra/manage-resources-cli for Cassandra API samples.
+  description: See https://docs.microsoft.com/azure/managed-instance-apache-cassandra/manage-resources-cli for Cassandra API samples.

--- a/2020-09-01-hybrid/docs-ref-autogen/ml/online-deployment.yml
+++ b/2020-09-01-hybrid/docs-ref-autogen/ml/online-deployment.yml
@@ -18,7 +18,7 @@ directCommands:
     Create a deployment. If the deployment already exists, it will fail. If you want to update existing deployment, use az ml online-deployment update.
   description: |-
     Minimum recommended compute SKU is Standard_DS3_v2 for general purpose endpoints. Learn more about SKUs here:
-    https://learn.microsoft.com/en-us/azure/machine-learning/reference-managed-online-endpoints-vm-sku-list.
+    https://learn.microsoft.com/azure/machine-learning/reference-managed-online-endpoints-vm-sku-list.
   status: GA
   sourceType: Extension
   syntax: >-

--- a/2020-09-01-hybrid/docs-ref-autogen/storage/entity.yml
+++ b/2020-09-01-hybrid/docs-ref-autogen/storage/entity.yml
@@ -198,7 +198,7 @@ directCommands:
       Storage account connection string. Environment variable: AZURE_STORAGE_CONNECTION_STRING.
   - name: --filter
     summary: |-
-      Returns only entities that satisfy the specified filter. Note that no more than 15 discrete comparisons are permitted within a $filter string. See http://msdn.microsoft.com/en-us/library/windowsazure/dd894031.aspx for more information on constructing filters.
+      Returns only entities that satisfy the specified filter. Note that no more than 15 discrete comparisons are permitted within a $filter string. See http://msdn.microsoft.com/library/windowsazure/dd894031.aspx for more information on constructing filters.
   - name: --marker
     summary: |-
       Space-separated list of key=value pairs. Must contain a nextpartitionkey and a nextrowkey.

--- a/2020-09-01-hybrid/docs-ref-autogen/stream-analytics/function.yml
+++ b/2020-09-01-hybrid/docs-ref-autogen/stream-analytics/function.yml
@@ -117,7 +117,7 @@ directCommands:
     description: |-
       Usage: --ml-properties execute-endpoint=XX
 
-      execute-endpoint: The Request-Response execute endpoint of the Azure Machine Learning web service. Find out more here: https://docs.microsoft.com/en-us/azure/stream-analytics/machine-learning-udf.
+      execute-endpoint: The Request-Response execute endpoint of the Azure Machine Learning web service. Find out more here: https://docs.microsoft.com/azure/stream-analytics/machine-learning-udf.
 - uid: az_stream-analytics_function_list
   name: az stream-analytics function list
   summary: |-

--- a/2020-09-01-hybrid/docs-ref-autogen/stream-analytics/job.yml
+++ b/2020-09-01-hybrid/docs-ref-autogen/stream-analytics/job.yml
@@ -71,7 +71,7 @@ directCommands:
       Valid values are JobStorageAccount and SystemAccount. If set to JobStorageAccount, this requires the user to also specify jobStorageAccount property. .
   - name: --data-locale
     summary: |-
-      The data locale of the stream analytics job. Value should be the name of a supported .NET Culture from the set https://msdn.microsoft.com/en-us/library/system.globalization.culturetypes(v=vs.110).aspx. Defaults to 'en-US' if none specified.
+      The data locale of the stream analytics job. Value should be the name of a supported .NET Culture from the set https://msdn.microsoft.com/library/system.globalization.culturetypes(v=vs.110).aspx. Defaults to 'en-US' if none specified.
   - name: --functions
     summary: |-
       A list of one or more functions for the streaming job. The name property for each function is required when specifying this property in a PUT request. This property cannot be modify via a PATCH operation. You must use the PATCH API available for the individual transformation. Expected value: json-string/json-file/@json-file.
@@ -401,7 +401,7 @@ directCommands:
       Valid values are JobStorageAccount and SystemAccount. If set to JobStorageAccount, this requires the user to also specify jobStorageAccount property. .
   - name: --data-locale
     summary: |-
-      The data locale of the stream analytics job. Value should be the name of a supported .NET Culture from the set https://msdn.microsoft.com/en-us/library/system.globalization.culturetypes(v=vs.110).aspx. Defaults to 'en-US' if none specified.
+      The data locale of the stream analytics job. Value should be the name of a supported .NET Culture from the set https://msdn.microsoft.com/library/system.globalization.culturetypes(v=vs.110).aspx. Defaults to 'en-US' if none specified.
   - name: --functions
     summary: |-
       A list of one or more functions for the streaming job. The name property for each function is required when specifying this property in a PUT request. This property cannot be modify via a PATCH operation. You must use the PATCH API available for the individual transformation. Expected value: json-string/json-file/@json-file.

--- a/2020-09-01-hybrid/docs-ref-autogen/vm/repair.yml
+++ b/2020-09-01-hybrid/docs-ref-autogen/vm/repair.yml
@@ -163,7 +163,7 @@ directCommands:
 - uid: az_vm_repair_reset-nic
   name: az vm repair reset-nic
   summary: |-
-    Reset the network interface stack on the VM guest OS. https://docs.microsoft.com/en-us/troubleshoot/azure/virtual-machines/reset-network-interface.
+    Reset the network interface stack on the VM guest OS. https://docs.microsoft.com/troubleshoot/azure/virtual-machines/reset-network-interface.
   status: Preview
   isPreview: true
   previewOrExperimentalInfo: 'This command is in preview and under development. Reference and support levels: https://aka.ms/CLI_refstatus'

--- a/ThirdPartyNotices
+++ b/ThirdPartyNotices
@@ -9,7 +9,7 @@ may be either trademarks or registered trademarks of Microsoft in the United Sta
 The licenses for this project do not grant you rights to use any Microsoft names, logos, or trademarks.
 Microsoft's general trademark guidelines can be found at http://go.microsoft.com/fwlink/?LinkID=254653.
 
-Privacy information can be found at https://privacy.microsoft.com/en-us/
+Privacy information can be found at https://privacy.microsoft.com/
 
 Microsoft and any contributors reserve all others rights, whether under their respective copyrights, patents,
 or trademarks, whether by implication, estoppel or otherwise.

--- a/latest/docs-ref-autogen/afd/rule.yml
+++ b/latest/docs-ref-autogen/afd/rule.yml
@@ -74,7 +74,7 @@ directCommands:
   optionalParameters:
   - name: --action-name
     summary: |-
-      The name of the action for the delivery rule: https://docs.microsoft.com/en-us/azure/frontdoor/front-door-rules-engine-actions.
+      The name of the action for the delivery rule: https://docs.microsoft.com/azure/frontdoor/front-door-rules-engine-actions.
   - name: --cache-behavior
     summary: |-
       Caching behavior for the requests.
@@ -126,7 +126,7 @@ directCommands:
       Match values of the match condition. e.g, space separated values 'GET' 'HTTP'.  Support shorthand-syntax, json-file and yaml-file. Try "??" to show more.
   - name: --match-variable
     summary: |-
-      Name of the match condition: https://docs.microsoft.com/en-us/azure/frontdoor/rules-match-conditions.
+      Name of the match condition: https://docs.microsoft.com/azure/frontdoor/rules-match-conditions.
   - name: --negate-condition
     parameterValueGroup: "0, 1, f, false, n, no, t, true, y, yes"
     summary: |-

--- a/latest/docs-ref-autogen/backup/protection.yml
+++ b/latest/docs-ref-autogen/backup/protection.yml
@@ -165,7 +165,7 @@ directCommands:
 - uid: az_backup_protection_check-vm
   name: az backup protection check-vm
   summary: |-
-    The command returns null/empty if the specified resource is not protected under any Recovery Services vault in the subscription. When configuring backup fails, it may return vault details. If Azure Backup is failing, then look for the corresponding error code in the Common issues section - https://learn.microsoft.com/en-us/azure/backup/backup-azure-vms-troubleshoot#common-issues. If it is protected, the relevant vault details will be returned.
+    The command returns null/empty if the specified resource is not protected under any Recovery Services vault in the subscription. When configuring backup fails, it may return vault details. If Azure Backup is failing, then look for the corresponding error code in the Common issues section - https://learn.microsoft.com/azure/backup/backup-azure-vms-troubleshoot#common-issues. If it is protected, the relevant vault details will be returned.
   status: GA
   sourceType: Core
   editLink: https://github.com/Azure/azure-cli/blob/dev/src/azure-cli/azure/cli/command_modules/backup/_help.py

--- a/latest/docs-ref-autogen/backup/restore.yml
+++ b/latest/docs-ref-autogen/backup/restore.yml
@@ -238,7 +238,7 @@ directCommands:
   - isRequired: true
     name: --storage-account
     summary: |-
-      Name or ID of the staging storage account. The VM configuration will be restored to this storage account. See the help for --restore-to-staging-storage-account parameter for more info. The ID might be needed for cross-region restores where the storage account and vault are not on the same resource group. In order to get the ID, use the storage account show command as specified here (https://learn.microsoft.com/en-us/azure/storage/common/storage-account-get-info?tabs=azure-cli#get-the-resource-id-for-a-storage-account).
+      Name or ID of the staging storage account. The VM configuration will be restored to this storage account. See the help for --restore-to-staging-storage-account parameter for more info. The ID might be needed for cross-region restores where the storage account and vault are not on the same resource group. In order to get the ID, use the storage account show command as specified here (https://learn.microsoft.com/azure/storage/common/storage-account-get-info?tabs=azure-cli#get-the-resource-id-for-a-storage-account).
   optionalParameters:
   - name: --container-name -c
     summary: |-

--- a/latest/docs-ref-autogen/cdn/endpoint/rule.yml
+++ b/latest/docs-ref-autogen/cdn/endpoint/rule.yml
@@ -64,7 +64,7 @@ directCommands:
     name: --action-name
     parameterValueGroup: "CacheExpiration, CacheKeyQueryString, ModifyRequestHeader, ModifyResponseHeader, OriginGroupOverride, UrlRedirect, UrlRewrite"
     summary: |-
-      The name of the action for the delivery rule: https://docs.microsoft.com/en-us/azure/cdn/cdn-standard-rules-engine-actions.
+      The name of the action for the delivery rule: https://docs.microsoft.com/azure/cdn/cdn-standard-rules-engine-actions.
   - isRequired: true
     name: --order
     summary: |-
@@ -111,7 +111,7 @@ directCommands:
   - name: --match-variable
     parameterValueGroup: "ClientPort, Cookies, HostName, HttpVersion, IsDevice, PostArgs, QueryString, RemoteAddress, RequestBody, RequestHeader, RequestMethod, RequestScheme, RequestUri, ServerPort, SocketAddr, SslProtocol, UrlFileExtension, UrlFileName, UrlPath"
     summary: |-
-      Name of the match condition: https://docs.microsoft.com/en-us/azure/cdn/cdn-standard-rules-engine-match-conditions.
+      Name of the match condition: https://docs.microsoft.com/azure/cdn/cdn-standard-rules-engine-match-conditions.
   - name: --name -n
     summary: |-
       Name of the CDN endpoint.

--- a/latest/docs-ref-autogen/dt/twin.yml
+++ b/latest/docs-ref-autogen/dt/twin.yml
@@ -144,7 +144,7 @@ directCommands:
   summary: |-
     Query the digital twins of an instance. Allows traversing relationships and filtering by property values.
   description: |-
-    In many twin queries, the `$` character is used to reference the `$dtId` property of a twin. In bash-like shells or powershell the `$` character has functional meaning and must be escaped as part of the query input. Please review the Digital Twins CLI concepts document https://docs.microsoft.com/en-us/azure/digital-twins/concepts-cli for more information.
+    In many twin queries, the `$` character is used to reference the `$dtId` property of a twin. In bash-like shells or powershell the `$` character has functional meaning and must be escaped as part of the query input. Please review the Digital Twins CLI concepts document https://docs.microsoft.com/azure/digital-twins/concepts-cli for more information.
   status: GA
   sourceType: Extension
   syntax: >-

--- a/latest/docs-ref-autogen/hdinsight-on-aks/cluster.yml
+++ b/latest/docs-ref-autogen/hdinsight-on-aks/cluster.yml
@@ -186,7 +186,7 @@ directCommands:
   - name: --db-connection-authentication-mode --spark-db-auth-mode
     parameterValueGroup: "IdentityAuth, SqlAuth"
     summary: |-
-      The authentication mode to connect to your Hive metastore database. More details: https://learn.microsoft.com/en-us/azure/azure-sql/database/logins-create-manage?view=azuresql#authentication-and-authorization.
+      The authentication mode to connect to your Hive metastore database. More details: https://learn.microsoft.com/azure/azure-sql/database/logins-create-manage?view=azuresql#authentication-and-authorization.
   - name: --deployment-mode
     parameterValueGroup: "Application, Session"
     summary: |-
@@ -214,7 +214,7 @@ directCommands:
   - name: --flink-db-auth-mode --metastore-db-connection-authentication-mode
     parameterValueGroup: "IdentityAuth, SqlAuth"
     summary: |-
-      The authentication mode to connect to your Hive metastore database. More details: https://learn.microsoft.com/en-us/azure/azure-sql/database/logins-create-manage?view=azuresql#authentication-and-authorization.
+      The authentication mode to connect to your Hive metastore database. More details: https://learn.microsoft.com/azure/azure-sql/database/logins-create-manage?view=azuresql#authentication-and-authorization.
   - name: --flink-hive-catalog-db-connection-password-secret --flink-hive-db-secret
     summary: |-
       Secret reference name from secretsProfile.secrets containing password for database connection.
@@ -721,7 +721,7 @@ directCommands:
   - name: --db-connection-authentication-mode --spark-db-auth-mode
     parameterValueGroup: "IdentityAuth, SqlAuth"
     summary: |-
-      The authentication mode to connect to your Hive metastore database. More details: https://learn.microsoft.com/en-us/azure/azure-sql/database/logins-create-manage?view=azuresql#authentication-and-authorization.
+      The authentication mode to connect to your Hive metastore database. More details: https://learn.microsoft.com/azure/azure-sql/database/logins-create-manage?view=azuresql#authentication-and-authorization.
   - name: --deployment-mode
     parameterValueGroup: "Application, Session"
     summary: |-
@@ -749,7 +749,7 @@ directCommands:
   - name: --flink-db-auth-mode --metastore-db-connection-authentication-mode
     parameterValueGroup: "IdentityAuth, SqlAuth"
     summary: |-
-      The authentication mode to connect to your Hive metastore database. More details: https://learn.microsoft.com/en-us/azure/azure-sql/database/logins-create-manage?view=azuresql#authentication-and-authorization.
+      The authentication mode to connect to your Hive metastore database. More details: https://learn.microsoft.com/azure/azure-sql/database/logins-create-manage?view=azuresql#authentication-and-authorization.
   - name: --flink-hive-catalog-db-connection-password-secret --flink-hive-db-secret
     summary: |-
       Secret reference name from secretsProfile.secrets containing password for database connection.

--- a/latest/docs-ref-autogen/iot/central.yml
+++ b/latest/docs-ref-autogen/iot/central.yml
@@ -19,7 +19,7 @@ directCommands:
   summary: |-
     Query device telemetry or property data with IoT Central Query Language.
   description: |-
-    For query syntax details, visit https://docs.microsoft.com/en-us/azure/iot-central/core/howto-query-with-rest-api.
+    For query syntax details, visit https://docs.microsoft.com/azure/iot-central/core/howto-query-with-rest-api.
   status: Preview
   isPreview: true
   previewOrExperimentalInfo: 'This command is in preview and under development. Reference and support levels: https://aka.ms/CLI_refstatus'

--- a/latest/docs-ref-autogen/iot/device.yml
+++ b/latest/docs-ref-autogen/iot/device.yml
@@ -94,7 +94,7 @@ directCommands:
     isPreview: true
   - name: --dtmi --model-id
     summary: |-
-      The Digital Twin Model Id the device will report when connecting to the hub. See https://docs.microsoft.com/en-us/azure/iot-develop/overview-iot-plug-and-play for more details.
+      The Digital Twin Model Id the device will report when connecting to the hub. See https://docs.microsoft.com/azure/iot-develop/overview-iot-plug-and-play for more details.
   - name: --hub-name -n
     summary: |-
       IoT Hub name or hostname. Required if --login is not provided.
@@ -214,7 +214,7 @@ directCommands:
       Message body. Provide text or raw json.
   - name: --dtmi --model-id
     summary: |-
-      The Digital Twin Model Id the device will report when connecting to the hub. See https://docs.microsoft.com/en-us/azure/iot-develop/overview-iot-plug-and-play for more details.
+      The Digital Twin Model Id the device will report when connecting to the hub. See https://docs.microsoft.com/azure/iot-develop/overview-iot-plug-and-play for more details.
   - name: --hub-name -n
     summary: |-
       IoT Hub name or hostname. Required if --login is not provided.

--- a/latest/docs-ref-autogen/iot/ops.yml
+++ b/latest/docs-ref-autogen/iot/ops.yml
@@ -157,7 +157,7 @@ directCommands:
     Bootstrap, configure and deploy IoT Operations to the target Arc-enabled cluster.
   description: |-
     For additional resources including how to Arc-enable a cluster see
-    https://learn.microsoft.com/en-us/azure/iot-operations/deploy-iot-ops/howto-prepare-cluster
+    https://learn.microsoft.com/azure/iot-operations/deploy-iot-ops/howto-prepare-cluster
 
     Note: Data Processor is not deployed by default. Use --include-dp to add it.
   status: Preview

--- a/latest/docs-ref-autogen/ml[v1]/model.yml
+++ b/latest/docs-ref-autogen/ml[v1]/model.yml
@@ -234,7 +234,7 @@ directCommands:
       A secondary auth key to use for this Webservice.
   - name: --lo --location
     summary: |-
-      The Azure region to deploy this Webservice to. If not specified the Workspace location will be used. More details on available regions can be found here: https://azure.microsoft.com/en-us/global-infrastructure/services/?regions=all&products=container-instances.
+      The Azure region to deploy this Webservice to. If not specified the Workspace location will be used. More details on available regions can be found here: https://azure.microsoft.com/global-infrastructure/services/?regions=all&products=container-instances.
   - name: --max-request-wait-time --mr
     summary: |-
       The maximum amount of time a request will stay in the queue (in milliseconds) before returning a 503 error. Defaults to 500.

--- a/latest/docs-ref-autogen/ml[v1]/service.yml
+++ b/latest/docs-ref-autogen/ml[v1]/service.yml
@@ -508,7 +508,7 @@ directCommands:
       A secondary auth key to use for this Webservice.
   - name: --lo --location
     summary: |-
-      The Azure region to deploy this Webservice to. If not specified the Workspace location will be used. More details on available regions can be found here: https://azure.microsoft.com/en-us/global-infrastructure/services/?regions=all&products=container-instances.
+      The Azure region to deploy this Webservice to. If not specified the Workspace location will be used. More details on available regions can be found here: https://azure.microsoft.com/global-infrastructure/services/?regions=all&products=container-instances.
   - name: --max-request-wait-time --mr
     summary: |-
       The maximum amount of time a request will stay in the queue (in milliseconds) before returning a 503 error. Defaults to 500.

--- a/latest/docs-ref-autogen/monitor/log-analytics/workspace.yml
+++ b/latest/docs-ref-autogen/monitor/log-analytics/workspace.yml
@@ -139,7 +139,7 @@ directCommands:
     Get the schema for a given workspace.
   description: |-
     Schema represents the internal structure of the workspace, which can be used during the query.
-    For more information, visit: https://docs.microsoft.com/en-us/rest/api/loganalytics/workspace-schema/get.
+    For more information, visit: https://docs.microsoft.com/rest/api/loganalytics/workspace-schema/get.
   status: GA
   sourceType: Core
   editLink: https://github.com/Azure/azure-cli/blob/dev/src/azure-cli/azure/cli/command_modules/monitor/_help.py

--- a/latest/docs-ref-autogen/sql/server/tde-key.yml
+++ b/latest/docs-ref-autogen/sql/server/tde-key.yml
@@ -34,7 +34,7 @@ directCommands:
 - uid: az_sql_server_tde-key_set
   name: az sql server tde-key set
   summary: |-
-    Sets the server's encryption protector. Ensure to create the key first https://docs.microsoft.com/en-us/cli/azure/sql/server/key?view=azure-cli-latest#az-sql-server-key-create.
+    Sets the server's encryption protector. Ensure to create the key first https://docs.microsoft.com/cli/azure/sql/server/key?view=azure-cli-latest#az-sql-server-key-create.
   status: GA
   sourceType: Core
   editLink: https://github.com/Azure/azure-cli/blob/dev/src/azure-cli/azure/cli/command_modules/sql/_help.py

--- a/latest/docs-ref-autogen/stream-analytics/function.yml
+++ b/latest/docs-ref-autogen/stream-analytics/function.yml
@@ -117,7 +117,7 @@ directCommands:
     description: |-
       Usage: --ml-properties execute-endpoint=XX
 
-      execute-endpoint: The Request-Response execute endpoint of the Azure Machine Learning web service. Find out more here: https://docs.microsoft.com/en-us/azure/stream-analytics/machine-learning-udf.
+      execute-endpoint: The Request-Response execute endpoint of the Azure Machine Learning web service. Find out more here: https://docs.microsoft.com/azure/stream-analytics/machine-learning-udf.
 - uid: az_stream-analytics_function_list
   name: az stream-analytics function list
   summary: |-

--- a/latest/docs-ref-autogen/stream-analytics/job.yml
+++ b/latest/docs-ref-autogen/stream-analytics/job.yml
@@ -71,7 +71,7 @@ directCommands:
       Valid values are JobStorageAccount and SystemAccount. If set to JobStorageAccount, this requires the user to also specify jobStorageAccount property. .
   - name: --data-locale
     summary: |-
-      The data locale of the stream analytics job. Value should be the name of a supported .NET Culture from the set https://msdn.microsoft.com/en-us/library/system.globalization.culturetypes(v=vs.110).aspx. Defaults to 'en-US' if none specified.
+      The data locale of the stream analytics job. Value should be the name of a supported .NET Culture from the set https://msdn.microsoft.com/library/system.globalization.culturetypes(v=vs.110).aspx. Defaults to 'en-US' if none specified.
   - name: --functions
     summary: |-
       A list of one or more functions for the streaming job. The name property for each function is required when specifying this property in a PUT request. This property cannot be modify via a PATCH operation. You must use the PATCH API available for the individual transformation. Expected value: json-string/json-file/@json-file.
@@ -401,7 +401,7 @@ directCommands:
       Valid values are JobStorageAccount and SystemAccount. If set to JobStorageAccount, this requires the user to also specify jobStorageAccount property. .
   - name: --data-locale
     summary: |-
-      The data locale of the stream analytics job. Value should be the name of a supported .NET Culture from the set https://msdn.microsoft.com/en-us/library/system.globalization.culturetypes(v=vs.110).aspx. Defaults to 'en-US' if none specified.
+      The data locale of the stream analytics job. Value should be the name of a supported .NET Culture from the set https://msdn.microsoft.com/library/system.globalization.culturetypes(v=vs.110).aspx. Defaults to 'en-US' if none specified.
   - name: --functions
     summary: |-
       A list of one or more functions for the streaming job. The name property for each function is required when specifying this property in a PUT request. This property cannot be modify via a PATCH operation. You must use the PATCH API available for the individual transformation. Expected value: json-string/json-file/@json-file.

--- a/latest/docs-ref-autogen/vm/repair.yml
+++ b/latest/docs-ref-autogen/vm/repair.yml
@@ -163,7 +163,7 @@ directCommands:
 - uid: az_vm_repair_reset-nic
   name: az vm repair reset-nic
   summary: |-
-    Reset the network interface stack on the VM guest OS. https://docs.microsoft.com/en-us/troubleshoot/azure/virtual-machines/reset-network-interface.
+    Reset the network interface stack on the VM guest OS. https://docs.microsoft.com/troubleshoot/azure/virtual-machines/reset-network-interface.
   status: Preview
   isPreview: true
   previewOrExperimentalInfo: 'This command is in preview and under development. Reference and support levels: https://aka.ms/CLI_refstatus'


### PR DESCRIPTION
As YML files are not overwritten constantly, we can at least fix this build validation error for older files. This will reduce our build validation error count.