### PR TITLE
Fix typo in Azure CLI documentation for 'ad user'

### DIFF
--- a/latest/docs-ref-autogen/ad/user.yml
+++ b/latest/docs-ref-autogen/ad/user.yml
@@ -22,7 +22,7 @@ directCommands:
                       [--mail-nickname]
   examples:
   - summary: |-
-      Create a user
+      Create a user.
     syntax: az ad user create --display-name myuser --password password --user-principal-name myuser@contoso.com
   requiredParameters:
   - isRequired: true
@@ -78,7 +78,7 @@ directCommands:
                                  [--security-enabled-only {false, true}]
   examples:
   - summary: |-
-      Get groups of which the user is a member
+      Get groups of which the user is a member.
     syntax: az ad user get-member-groups --id myuser@contoso.com
   requiredParameters:
   - isRequired: true


### PR DESCRIPTION
Related to #4695

Corrects typos in the Azure CLI documentation for 'ad user'.

* **Examples Section**
  - Adds a period at the end of the summary for creating a user.
  - Adds a period at the end of the summary for getting groups of which the user is a member.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MicrosoftDocs/azure-docs-cli/issues/4695?shareId=afa7c927-0abb-4a43-8f66-c6020bfdf449).