### PR TITLE
docfx.json | update customer feedback settings

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -215,11 +215,11 @@
         "*/docs-ref-autogen/redis/**": [ "Cache for Redis", "Azure", "Azure CLI" ]
       },
       "open_source_feedback_issueUrl": {
-         "2017-*/**/*": "https://github.com/Azure/azure-cli/issues/new/new?docs_feedback.yml",
-         "2018-*/**/*": "https://github.com/Azure/azure-cli/issues/new/new?docs_feedback.yml",
-         "2019-*/**/*": "https://github.com/Azure/azure-cli/issues/new/new?docs_feedback.yml",
-         "2020-*/**/*": "https://github.com/Azure/azure-cli/issues/new/new?docs_feedback.yml",
-         "latest/**/*": "https://github.com/Azure/azure-cli/issues/new/new?docs_feedback.yml",
+         "2017-*/**/*": "https://github.com/Azure/azure-cli/issues/new?docs_feedback.yml",
+         "2018-*/**/*": "https://github.com/Azure/azure-cli/issues/new?docs_feedback.yml",
+         "2019-*/**/*": "https://github.com/Azure/azure-cli/issues/new?docs_feedback.yml",
+         "2020-*/**/*": "https://github.com/Azure/azure-cli/issues/new?docs_feedback.yml",
+         "latest/**/*": "https://github.com/Azure/azure-cli/issues/new?docs_feedback.yml",
          "docs-ref-conceptual/**/*": "https://github.com/MicrosoftDocs/azure-docs-cli/issues/new?template=UUF-Customer-Feedback.yml",
       }
     },

--- a/docfx.json
+++ b/docfx.json
@@ -215,11 +215,11 @@
         "*/docs-ref-autogen/redis/**": [ "Cache for Redis", "Azure", "Azure CLI" ]
       },
       "open_source_feedback_issueUrl": {
-         "2017-*/**/*": "https://github.com/Azure/azure-cli/issues/new?docs_feedback.yml",
-         "2018-*/**/*": "https://github.com/Azure/azure-cli/issues/new?docs_feedback.yml",
-         "2019-*/**/*": "https://github.com/Azure/azure-cli/issues/new?docs_feedback.yml",
-         "2020-*/**/*": "https://github.com/Azure/azure-cli/issues/new?docs_feedback.yml",
-         "latest/**/*": "https://github.com/Azure/azure-cli/issues/new?docs_feedback.yml",
+         "2017-*/**/*": "https://github.com/Azure/azure-cli/issues/new?template=docs_feedback.yml",
+         "2018-*/**/*": "https://github.com/Azure/azure-cli/issues/new?template=docs_feedback.yml",
+         "2019-*/**/*": "https://github.com/Azure/azure-cli/issues/new?template=docs_feedback.yml",
+         "2020-*/**/*": "https://github.com/Azure/azure-cli/issues/new?template=docs_feedback.yml",
+         "latest/**/*": "https://github.com/Azure/azure-cli/issues/new?template=docs_feedback.yml",
          "docs-ref-conceptual/**/*": "https://github.com/MicrosoftDocs/azure-docs-cli/issues/new?template=UUF-Customer-Feedback.yml",
       }
     },

--- a/docfx.json
+++ b/docfx.json
@@ -33,7 +33,7 @@
           "2019-*/**/*": "reference",
           "2020-*/**/*": "reference",
           "latest/**/*": "reference",
-          "docs-ref-conceptual/**/*": "conceptual"
+          "docs-ref-conceptual/**/*": "concept-article"
       },
       "ms.service": {
         "*/docs-ref-autogen/account.yml": "azure",
@@ -242,7 +242,6 @@
       "ms.date": "05/21/2024",
       "ms.devlang": "azurecli",
       "ms.service": "azure-cli",
-      "ms.topic": "reference",
       "searchScope": [ "Azure", "Azure CLI" ],
       "showPowerShellPicker": "true",
       "uhfHeaderId": "Azure"

--- a/docfx.json
+++ b/docfx.json
@@ -27,6 +27,14 @@
       "devlang": {
         "*/docs-ref-autogen/**": "azurecli"
       },
+      "ms.topic": {
+          "2017-*/**/*": "reference",
+          "2018-*/**/*": "reference",
+          "2019-*/**/*": "reference",
+          "2020-*/**/*": "reference",
+          "latest/**/*": "reference",
+          "docs-ref-conceptual/**/*": "conceptual"
+      },
       "ms.service": {
         "*/docs-ref-autogen/account.yml": "azure",
         "*/docs-ref-autogen/account/**": "azure",
@@ -205,6 +213,14 @@
         "*/docs-ref-autogen/postgres/**": [ "Azure Database for PostgreSQL", "Azure", "Azure CLI" ],
         "*/docs-ref-autogen/redis.yml": [ "Cache for Redis", "Azure", "Azure CLI" ],
         "*/docs-ref-autogen/redis/**": [ "Cache for Redis", "Azure", "Azure CLI" ]
+      },
+      "open_source_feedback_issueUrl": {
+         "2017-*/**/*": "https://github.com/Azure/azure-cli/issues",
+         "2018-*/**/*": "https://github.com/Azure/azure-cli/issues",
+         "2019-*/**/*": "https://github.com/Azure/azure-cli/issues",
+         "2020-*/**/*": "https://github.com/Azure/azure-cli/issues",
+         "latest/**/*": "https://github.com/Azure/azure-cli/issues",
+         "docs-ref-conceptual/**/*": "https://github.com/MicrosoftDocs/azure-docs-cli/issues/new?template=UUF-Customer-Feedback.yml",
       }
     },
     "globalMetadata": {
@@ -217,7 +233,6 @@
       "open_source_feedback_contributorGuideUrl": "https://learn.microsoft.com/contribute/content/how-to-write-overview",
       "open_source_feedback_issueLabels": "needs-triage",
       "open_source_feedback_issueTitle": "",
-      "open_source_feedback_issueUrl": "https://github.com/MicrosoftDocs/azure-docs-cli/issues/new?template=UUF-Customer-Feedback.yml",
       "open_source_feedback_productLogoDarkUrl": "https://learn.microsoft.com/media/logos/logo_azure.svg",
       "open_source_feedback_productLogoLightUrl": "https://learn.microsoft.com/media/logos/logo_azure.svg",
       "open_source_feedback_productName": "Azure CLI",

--- a/docfx.json
+++ b/docfx.json
@@ -215,11 +215,11 @@
         "*/docs-ref-autogen/redis/**": [ "Cache for Redis", "Azure", "Azure CLI" ]
       },
       "open_source_feedback_issueUrl": {
-         "2017-*/**/*": "https://github.com/Azure/azure-cli/issues",
-         "2018-*/**/*": "https://github.com/Azure/azure-cli/issues",
-         "2019-*/**/*": "https://github.com/Azure/azure-cli/issues",
-         "2020-*/**/*": "https://github.com/Azure/azure-cli/issues",
-         "latest/**/*": "https://github.com/Azure/azure-cli/issues",
+         "2017-*/**/*": "https://github.com/Azure/azure-cli/issues/new/choose",
+         "2018-*/**/*": "https://github.com/Azure/azure-cli/issues/new/choose",
+         "2019-*/**/*": "https://github.com/Azure/azure-cli/issues/new/choose",
+         "2020-*/**/*": "https://github.com/Azure/azure-cli/issues/new/choose",
+         "latest/**/*": "https://github.com/Azure/azure-cli/issues/new/choose",
          "docs-ref-conceptual/**/*": "https://github.com/MicrosoftDocs/azure-docs-cli/issues/new?template=UUF-Customer-Feedback.yml",
       }
     },

--- a/docfx.json
+++ b/docfx.json
@@ -215,11 +215,11 @@
         "*/docs-ref-autogen/redis/**": [ "Cache for Redis", "Azure", "Azure CLI" ]
       },
       "open_source_feedback_issueUrl": {
-         "2017-*/**/*": "https://github.com/Azure/azure-cli/issues/new/choose",
-         "2018-*/**/*": "https://github.com/Azure/azure-cli/issues/new/choose",
-         "2019-*/**/*": "https://github.com/Azure/azure-cli/issues/new/choose",
-         "2020-*/**/*": "https://github.com/Azure/azure-cli/issues/new/choose",
-         "latest/**/*": "https://github.com/Azure/azure-cli/issues/new/choose",
+         "2017-*/**/*": "https://github.com/Azure/azure-cli/issues/new/new?docs_feedback.yml",
+         "2018-*/**/*": "https://github.com/Azure/azure-cli/issues/new/new?docs_feedback.yml",
+         "2019-*/**/*": "https://github.com/Azure/azure-cli/issues/new/new?docs_feedback.yml",
+         "2020-*/**/*": "https://github.com/Azure/azure-cli/issues/new/new?docs_feedback.yml",
+         "latest/**/*": "https://github.com/Azure/azure-cli/issues/new/new?docs_feedback.yml",
          "docs-ref-conceptual/**/*": "https://github.com/MicrosoftDocs/azure-docs-cli/issues/new?template=UUF-Customer-Feedback.yml",
       }
     },


### PR DESCRIPTION
Aligning with Azure PowerShell, GitHub issues on autogenerated reference content should route directly to the engineering source code repos