### PR TITLE
Add completion troubleshooting guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ _themes/
 _themes.MSDN.Modern/
 _themes.VS.Modern/
 .vscode
-.idea
 
 .openpublishing.buildcore.ps1
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ _themes/
 _themes.MSDN.Modern/
 _themes.VS.Modern/
 .vscode
+.idea
 
 .openpublishing.buildcore.ps1
 *.swp

--- a/docs-ref-conceptual/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-apt.md
@@ -237,3 +237,5 @@ If your proxy doesn't use basic auth, __remove__ the `[username]:[password]@` po
 In order to get the Microsoft signing key and get the package from our repository, your proxy needs to allow HTTPS connections to the following address: `https://packages.microsoft.com.
 
 [!INCLUDE[troubleshoot-wsl.md](troubleshoot-wsl.md)]
+
+[!INCLUDE[linux-completion.md](linux-completion.md)]

--- a/docs-ref-conceptual/includes/cli-install-linux-dnf.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-dnf.md
@@ -193,3 +193,5 @@ allow HTTPS connections to the following address:
 * `https://packages.microsoft.com`
 
 [!INCLUDE[troubleshoot-wsl.md](troubleshoot-wsl.md)]
+
+[!INCLUDE[linux-completion.md](linux-completion.md)]

--- a/docs-ref-conceptual/includes/cli-install-linux-tdnf.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-tdnf.md
@@ -62,4 +62,6 @@ sudo tdnf remove azure-cli
 
 [!INCLUDE [remove-data-boilerplate.md](remove-data-boilerplate.md)]
 
+## Troubleshooting
+
 [!INCLUDE[linux-completion.md](linux-completion.md)]

--- a/docs-ref-conceptual/includes/cli-install-linux-tdnf.md
+++ b/docs-ref-conceptual/includes/cli-install-linux-tdnf.md
@@ -61,3 +61,5 @@ sudo tdnf remove azure-cli
 ### Remove data
 
 [!INCLUDE [remove-data-boilerplate.md](remove-data-boilerplate.md)]
+
+[!INCLUDE[linux-completion.md](linux-completion.md)]

--- a/docs-ref-conceptual/includes/linux-completion.md
+++ b/docs-ref-conceptual/includes/linux-completion.md
@@ -6,7 +6,7 @@ ms.topic: include
 ---
 ### Completion isn't working
 
-For Bash users, the completion script is installed in `/etc/bash_completion.d/azure-cli`. Add the following line to your `~/.bashrc` file, then save and reload your Bash profile:
+For Bash users, the completion script is installed in `/etc/bash_completion.d/azure-cli`. If it is not automatically executed, add the following line to your `~/.bashrc` file, then save and reload your Bash profile:
 
 ```bash
 source /etc/bash_completion.d/azure-cli

--- a/docs-ref-conceptual/includes/linux-completion.md
+++ b/docs-ref-conceptual/includes/linux-completion.md
@@ -6,7 +6,7 @@ ms.topic: include
 ---
 ### Completion isn't working
 
-For Bash users, the completion script is installed in `/etc/bash_completion.d/azure-cli`, which should be loaded automatically. If it doesn't work, you can manually add the following line to your `~/.bashrc` file, then save and reload your Bash profile:
+For Bash users, the completion script is installed in `/etc/bash_completion.d/azure-cli`. Please add the following line to your `~/.bashrc` file, then save and reload your Bash profile:
 
 ```bash
 source /etc/bash_completion.d/azure-cli

--- a/docs-ref-conceptual/includes/linux-completion.md
+++ b/docs-ref-conceptual/includes/linux-completion.md
@@ -1,0 +1,20 @@
+---
+author: bebound
+ms.author: hanglei
+ms.date: 11/29/2024
+ms.topic: include
+---
+### Completion isn't working
+
+For Bash users, the completion script is installed in `/etc/bash_completion.d/azure-cli`, which should be loaded automatically. If it doesn't work, you can manually add the following line to your `~/.bashrc` file, then save and reload your Bash profile:
+
+```bash
+source /etc/bash_completion.d/azure-cli
+```
+
+For Zsh users, please add the following two lines in your `~/.zshrc` file, then save and reload your Zsh profile:
+
+```zsh
+autoload -U +X bashcompinit && bashcompinit
+source /etc/bash_completion.d/azure-cli
+```

--- a/docs-ref-conceptual/includes/linux-completion.md
+++ b/docs-ref-conceptual/includes/linux-completion.md
@@ -6,13 +6,13 @@ ms.topic: include
 ---
 ### Completion isn't working
 
-For Bash users, the completion script is installed in `/etc/bash_completion.d/azure-cli`. Please add the following line to your `~/.bashrc` file, then save and reload your Bash profile:
+For Bash users, the completion script is installed in `/etc/bash_completion.d/azure-cli`. Add the following line to your `~/.bashrc` file, then save and reload your Bash profile:
 
 ```bash
 source /etc/bash_completion.d/azure-cli
 ```
 
-For Zsh users, please add the following two lines in your `~/.zshrc` file, then save and reload your Zsh profile:
+For Zsh users, add the following two lines in your `~/.zshrc` file, then save and reload your Zsh profile:
 
 ```zsh
 autoload -U +X bashcompinit && bashcompinit

--- a/docs-ref-conceptual/install-azure-cli-macos.md
+++ b/docs-ref-conceptual/install-azure-cli-macos.md
@@ -38,7 +38,7 @@ If you encounter a problem when installing the CLI through Homebrew, here are so
 
 ### Completion isn't working
 
-The Homebrew formula of Azure CLI installs a completion file named `az` in the Homebrew-managed completions directory (default location is `/usr/local/etc/bash_completion.d/`). To enable completion, follow Homebrew's instructions [here](https://docs.brew.sh/Shell-Completion).
+The Homebrew formula of Azure CLI installs a completion file named `az` in the Homebrew-managed completions directory (default location is `$(brew --prefix)/etc/bash_completion.d/`). To enable completion, follow Homebrew's instructions [here](https://docs.brew.sh/Shell-Completion).
 
 For Zsh, add the following two lines to the bottom of your `.zshrc` file, then save and reload your Zsh profile.
 


### PR DESCRIPTION
Currently, there is no guide for tab completion for Linux.

Related issue: https://github.com/Azure/azure-cli/issues/30441