### PR TITLE
Remove extra dash in example command

### DIFF
--- a/docs-ref-conceptual/azure-cli-sp-tutorial-5.md
+++ b/docs-ref-conceptual/azure-cli-sp-tutorial-5.md
@@ -76,7 +76,7 @@ The changes can be verified by listing the assigned roles:
 
 ```azurecli-interactive
 # list all role assignments for the current subscription
-az role assignment list ---output table
+az role assignment list --output table
 
 # list role assignments for a user
 az role assignment list --assignee myUserName@contoso.com


### PR DESCRIPTION
The example command has `---output table` which I assume is a typo for `--output table`.

```bash
az role assignment list ---output table
unrecognized arguments: ---output table
```