### PR TITLE
Update use-azure-cli-successfully-troubleshooting.md

### DIFF
--- a/docs-ref-conceptual/use-azure-cli-successfully-troubleshooting.md
+++ b/docs-ref-conceptual/use-azure-cli-successfully-troubleshooting.md
@@ -201,7 +201,7 @@ If you're using Azure CLI over a proxy server that uses self-signed certificates
 | Windows 64-bit | `C:\Program Files\Microsoft SDKs\Azure\CLI2\Lib\site-packages\certifi\cacert.pem` |
 | Ubuntu/Debian Linux | `/opt/az/lib/python<version>/site-packages/certifi/cacert.pem` |
 | CentOS Stream/RHEL/SUSE Linux | `/usr/lib64/az/lib/python<version>/site-packages/certifi/cacert.pem` |
-| macOS | `/usr/local/Cellar/azure-cli/<cliversion>/libexec/lib/python<version>/site-packages/certifi/cacert.pem` |
+| macOS | `/usr/local/Cellar/azure-cli/<cliversion>/libexec/lib/python<version>/site-packages/certifi/cacert.pem` <br><br>Homebrew installation: `/opt/homebrew/Cellar/azure-cli/<cliversion>/libexec/lib/python<version>/site-packages/certifi/cacert.pem`|
 
 Append the proxy server's certificate to the CA bundle certificate file, or copy the contents to another certificate file. Then set `REQUESTS_CA_BUNDLE` to the new file location. Here's an example:
 

--- a/docs-ref-conceptual/use-azure-cli-successfully-troubleshooting.md
+++ b/docs-ref-conceptual/use-azure-cli-successfully-troubleshooting.md
@@ -201,7 +201,7 @@ If you're using Azure CLI over a proxy server that uses self-signed certificates
 | Windows 64-bit | `C:\Program Files\Microsoft SDKs\Azure\CLI2\Lib\site-packages\certifi\cacert.pem` |
 | Ubuntu/Debian Linux | `/opt/az/lib/python<version>/site-packages/certifi/cacert.pem` |
 | CentOS Stream/RHEL/SUSE Linux | `/usr/lib64/az/lib/python<version>/site-packages/certifi/cacert.pem` |
-| macOS | `/usr/local/Cellar/azure-cli/<cliversion>/libexec/lib/python<version>/site-packages/certifi/cacert.pem` <br><br>Homebrew installation: `/opt/homebrew/Cellar/azure-cli/<cliversion>/libexec/lib/python<version>/site-packages/certifi/cacert.pem`|
+| macOS | Intel models: `/usr/local/Cellar/azure-cli/<cliversion>/libexec/lib/python<version>/site-packages/certifi/cacert.pem` <br><br>Silicon models: `/opt/homebrew/Cellar/azure-cli/<cliversion>/libexec/lib/python<version>/site-packages/certifi/cacert.pem`|
 
 Append the proxy server's certificate to the CA bundle certificate file, or copy the contents to another certificate file. Then set `REQUESTS_CA_BUNDLE` to the new file location. Here's an example:
 


### PR DESCRIPTION
Adding the path for certificate where azure-cli is installed using homebrew