### PR TITLE
Update .openpublishing.redirection.delete-service-page.json

### DIFF
--- a/.openpublishing.redirection.delete-service-page.json
+++ b/.openpublishing.redirection.delete-service-page.json
@@ -2186,22 +2186,22 @@
             "redirect_document_id": false
          },
          {
-            "source_path": "2017-03-09-profile/docs-ref-autogen/service-page/api%20for%20fhir.yml",
+            "source_path": "2017-03-09-profile/docs-ref-autogen/service-page/API for FHIR.yml",
             "redirect_url": "/cli/azure/service-page/health%20data%20services",
             "redirect_document_id": false
          },
          {
-            "source_path": "2018-03-01-hybrid/docs-ref-autogen/service-page/api%20for%20fhir.yml",
+            "source_path": "2018-03-01-hybrid/docs-ref-autogen/service-page/API for FHIR.yml",
             "redirect_url": "/cli/azure/service-page/health%20data%20services",
             "redirect_document_id": false
          },
          {
-            "source_path": "2020-09-01-hybrid/docs-ref-autogen/service-page/api%20for%20fhir.yml",
+            "source_path": "2020-09-01-hybrid/docs-ref-autogen/service-page/API for FHIR.yml",
             "redirect_url": "/cli/azure/service-page/health%20data%20services",
             "redirect_document_id": false
          },
          {
-            "source_path": "latest/docs-ref-autogen/service-page/api%20for%20fhir.yml",
+            "source_path": "latest/docs-ref-autogen/service-page/API for FHIR.yml",
             "redirect_url": "/cli/azure/service-page/health%20data%20services",
             "redirect_document_id": false
          }


### PR DESCRIPTION
Fixed incorrect redirect for old `API for RHIR` service page