### PR TITLE
Changing option -v for --mount in bind mount declaration for azure cli docker run command

### DIFF
--- a/docs-ref-conceptual/run-azure-cli-docker.md
+++ b/docs-ref-conceptual/run-azure-cli-docker.md
@@ -29,10 +29,10 @@ docker run -it mcr.microsoft.com/azure-cli:cbl-mariner2.0
 
 > [!NOTE]
 > If you want to pick up the SSH keys from your user environment,
-> use `-v ${HOME}/.ssh:/root/.ssh` to mount your SSH keys in the environment.
+> use `--mount type=bind,src="$HOME"/.ssh,dst=/root/.ssh` to mount your SSH keys in the environment.
 >
 > ```bash
-> docker run -it -v ${HOME}/.ssh:/root/.ssh mcr.microsoft.com/azure-cli:cbl-mariner2.0
+> docker run -it --mount type=bind,src="$HOME"/.ssh,dst=/root/.ssh mcr.microsoft.com/azure-cli:cbl-mariner2.0
 > ```
 
 The CLI is installed on the image as the `az` command in `/usr/local/bin`.


### PR DESCRIPTION
## Changing option `-v` for `--mount` in bind mount declaration

Bind mount was declared with the option `-v`, it is now  declared with the option `--mount` according to the  recommendations that can be found in the [docker reference](https://docs.docker.com/reference/) and the [docker engine manual](https://docs.docker.com/engine/)

## **Explanation**

1. In the [volumes](https://docs.docker.com/engine/storage/volumes/#syntax) section of the docker engine manual where it is written that : "In general, `--mount` is preferred. The main difference is that the `--mount` flag is more explicit and supports all the available options."
2. in the [bind mount](https://docs.docker.com/engine/storage/bind-mounts/#syntax) section of the docker engine manual where the same sentence is written
3. in the [bind mount](https://docs.docker.com/reference/cli/docker/container/run/#mount) section of the [docker run reference](https://docs.docker.com/reference/cli/docker/container/run/) where it is written that : "Even though there is no plan to deprecate `--volume`, usage of `--mount` is recommended."