### PR TITLE
Add a note below REQUESTS_CA_BUNDLE steps

### DIFF
--- a/docs-ref-conceptual/use-azure-cli-successfully-troubleshooting.md
+++ b/docs-ref-conceptual/use-azure-cli-successfully-troubleshooting.md
@@ -195,6 +195,8 @@ See [Work behind a proxy](#work-behind-a-proxy) for information on how to resolv
 
 If you're using Azure CLI over a proxy server that uses self-signed certificates, the Python [requests library](https://github.com/kennethreitz/requests) used by the Azure CLI might cause the following error: `SSLError("bad handshake: Error([('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')],)",)`. To address this error, set the environment variable `REQUESTS_CA_BUNDLE` to the path of CA bundle certificate file in PEM format.
 
+Additionally, if you were previously logged in, and your network administrator has recently added an intercepting proxy, you may need to login again after setting the above variable in order for the updated bundle to be retrieved and cached.
+
 | OS | Default certificate authority bundle |
 |---|---|
 | Windows 32-bit | `C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\Lib\site-packages\certifi\cacert.pem` |


### PR DESCRIPTION
In the case where a user has previously authenticated to Azure via the CLI, once the network administrator adds an intercepting proxy, and a user sets the REQUESTS_CA_BUNDLE variable, the Azure CLI may still throw certificate verify failed errors despite the proper certificate file path being provided to the variable until the `az login` command has been run post to setting the above variable.

This note makes it clear that after setting the REQUESTS_CA_BUNDLE variable, users should login again to ensure the proper certificate (the one with the CA rewritten by the intercepting proxy) is cached and used for subsequent requests.