### PR TITLE
Bugfix/login to azure cli after setting requests ca bundle

### DIFF
--- a/docs-ref-conceptual/use-azure-cli-successfully-troubleshooting.md
+++ b/docs-ref-conceptual/use-azure-cli-successfully-troubleshooting.md
@@ -195,6 +195,8 @@ See [Work behind a proxy](#work-behind-a-proxy) for information on how to resolv
 
 If you're using Azure CLI over a proxy server that uses self-signed certificates, the Python [requests library](https://github.com/kennethreitz/requests) used by the Azure CLI might cause the following error: `SSLError("bad handshake: Error([('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')],)",)`. To address this error, set the environment variable `REQUESTS_CA_BUNDLE` to the path of CA bundle certificate file in PEM format.
 
+Additionally, if you were previously logged in, and your network administrator has recently added an intercepting proxy, you may need to login again after setting the above variable in order for the updated bundle to be retrieved and cached.
+
 | OS | Default certificate authority bundle |
 |---|---|
 | Windows 32-bit | `C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\Lib\site-packages\certifi\cacert.pem` |

--- a/docs-ref-conceptual/use-azure-cli-successfully-troubleshooting.md
+++ b/docs-ref-conceptual/use-azure-cli-successfully-troubleshooting.md
@@ -195,7 +195,7 @@ See [Work behind a proxy](#work-behind-a-proxy) for information on how to resolv
 
 If you're using Azure CLI over a proxy server that uses self-signed certificates, the Python [requests library](https://github.com/kennethreitz/requests) used by the Azure CLI might cause the following error: `SSLError("bad handshake: Error([('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')],)",)`. To address this error, set the environment variable `REQUESTS_CA_BUNDLE` to the path of CA bundle certificate file in PEM format.
 
-Additionally, if you were previously logged in, and your network administrator has recently added an intercepting proxy, you may need to login again after setting the above variable in order for the updated bundle to be retrieved and cached.
+Additionally, if you were previously logged in, and your network administrator has recently added an intercepting proxy, you may need to login again after setting the above variable in order to avoid CA-related errors.
 
 | OS | Default certificate authority bundle |
 |---|---|


### PR DESCRIPTION
Follow-up to #4978, which was closed (I believe prematurely):

The Azure CLI may throw certificate verify failed errors after performing the instructions as currently published until the `az login` command has been run even after the user properly adds the intercepting proxy CA certificate to the trust bundle and sets the `REQUESTS_CA_BUNDLE` variable.

This note makes it clear that after setting the variable, users should login again to ensure that all requests to Azure trust the intercepting proxy's certificate, which mitigates the errors.

I have updated the language to not mention caching, however I would like to point @jiasli to https://stackoverflow.com/questions/20198274/how-do-i-clear-cache-with-python-requests/55613686#comment124524023_55613686 which effectively means that unless the Azure CLI is sending the `Cache-Control` header, the "server" may be caching something. "Server" is used here to loosely to mean anything in between the client running the Azure CLI, and the actual destination service in Azure which receives the requests from the CLI and sends the response.

I don't have the ability to debug the issue in my environment due to corporate restrictions, and the fact that my system now properly trusts the intercepting proxy's CA certificate and I've already re-logged in to the Azure CLI since our intercepting proxy was added, so it is entirely possible that the issue is not "cache" related but there is _something_ which caused certificate verify failed errors AFTER I followed the currently published instructions, and the only solution I found was to login again so I strongly feel that the docs should mention to login again regardless of whether this is a cache related issue or not.