### PR TITLE
(AzureCXP) fixes MicrosoftDocs/azure-docs#374669

### DIFF
--- a/2018-03-01-hybrid/docs-ref-autogen/storage/account/keys.yml
+++ b/2018-03-01-hybrid/docs-ref-autogen/storage/account/keys.yml
@@ -47,8 +47,8 @@ directCommands:
                                   [--resource-group]
   examples:
   - summary: |-
-      Regenerate one of the access keys for a storage account.
-    syntax: az storage account keys renew -g MyResourceGroup -n MyStorageAccount --key primary
+      Regenerating an access key will regenerate both Key 1 and Key 2, not just the specified key.
+    syntax: az storage account keys renew -g MyResourceGroup -n MyStorageAccount --key key1
   - summary: |-
       Regenerate one of the Kerberos keys for a storage account.
     syntax: az storage account keys renew -g MyResourceGroup -n MyStorageAccount --key secondary --key-type kerb


### PR DESCRIPTION
Updated line no: 50  from "Regenerate one of the access keys for a storage account." to "Regenerating an access key will regenerate both Key 1 and Key 2, not just the specified key." and  line no : 51  from "az storage account keys renew -g MyResourceGroup -n MyStorageAccount --key primary" to "az storage account keys renew -g MyResourceGroup -n MyStorageAccount --key key1"