### PR TITLE
Update Azure CLI docs to remove reference to unsupported command

### DIFF
--- a/docs-ref-conceptual/Latest-version/authenticate-azure-cli-managed-identity.md
+++ b/docs-ref-conceptual/Latest-version/authenticate-azure-cli-managed-identity.md
@@ -25,10 +25,16 @@ az login --identity
 ```
 
 To sign in with a user-assigned managed identity, specify the client ID, object ID, or resource ID
-of the user-assigned managed identity with `--username`:
+of the user-assigned managed identity with `--client-id`, `--object-id`, or `--resource-id` respectively:
 
 ```azurecli-interactive
-az login --identity --username <client_id|object_id|resource_id>
+az login --identity --client-id <client_id>
+```
+```azurecli-interactive
+az login --identity --object-id <object_id>
+```
+```azurecli-interactive
+az login --identity --resource-id <resource_id>
 ```
 
 To learn more about managed identities for Azure resources, see


### PR DESCRIPTION


# PR Summary

This PR updates the documentation for Azure CLI to remove a reference to an unsupported command option. Passing the managed identity ID with --username is no longer supported. Use --client-id, --object-id or --resource-id instead.

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [X ] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [X] **Summary:** This PR's summary describes the scope and intent of the change.
