### PR TITLE
Update config variable

### DIFF
--- a/docs-ref-conceptual/Latest-version/azure-cli-configuration.md
+++ b/docs-ref-conceptual/Latest-version/azure-cli-configuration.md
@@ -58,7 +58,7 @@ az config set defaults.location=westus2 defaults.group=MyResourceGroup
 The following command turns off the survey links while executing the Azure CLI commands:
 
 ```azurecli-interactive
-az config set output.show_survey_link=no
+az config set core.survey_message=no
 ```
 
 ## CLI configuration file


### PR DESCRIPTION
output.show_survey_link no longer works, it's been substituted by core.survey_message as evidenced in [#Azure/azure-cli/25242](https://github.com/Azure/azure-cli/issues/25242#issuecomment-1409789481)

# PR Summary

This change fixes invalid config options in the documentation for azure-cli.
- Fixes [#Azure/azure-cli/25242](https://github.com/Azure/azure-cli/issues/25242)

## PR Checklist


- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.

