### PR TITLE
Removing References to Web Application Routing

### DIFF
--- a/docs-ref-autogen/Latest-version/latest/aks.yml
+++ b/docs-ref-autogen/Latest-version/latest/aks.yml
@@ -1606,7 +1606,7 @@ directCommands:
       This address must be within the Kubernetes service address range specified by "--service-cidr". For example, 10.0.0.10.
   - name: --dns-zone-resource-ids
     summary: |-
-      A comma separated list of resource IDs of the DNS zone resource to use with the web_application_routing addon.
+      A comma separated list of resource IDs of the DNS zone resource to use with the App Routing addon.
     isPreview: true
   - name: --edge-zone
     summary: |-
@@ -1632,7 +1632,7 @@ directCommands:
       - open-service-mesh               : enable Open Service Mesh addon (PREVIEW).
       - gitops                          : enable GitOps (PREVIEW).
       - azure-keyvault-secrets-provider : enable Azure Keyvault Secrets Provider addon.
-      - web_application_routing         : enable Web Application Routing addon (PREVIEW). Specify "--dns-zone-resource-id" to configure DNS.
+      - web_application_routing         : enable the App Routing addon (PREVIEW). Specify "--dns-zone-resource-id" to configure DNS.
   - name: --enable-ahub
     defaultValue: "False"
     summary: |-
@@ -2530,7 +2530,7 @@ directCommands:
         open-service-mesh               - enable Open Service Mesh addon (PREVIEW).
         gitops                          - enable GitOps (PREVIEW).
         azure-keyvault-secrets-provider - enable Azure Keyvault Secrets Provider addon.
-        web_application_routing         - enable Web Application Routing addon (PREVIEW). Specify "--dns-zone-resource-id" to configure DNS.
+        web_application_routing         - enable the App Routing addon (PREVIEW). Specify "--dns-zone-resource-id" to configure DNS.
   status: GA
   sourceType: Extension
   syntax: >-
@@ -2607,7 +2607,7 @@ directCommands:
     isPreview: true
   - name: --dns-zone-resource-ids
     summary: |-
-      A comma separated list of resource IDs of the DNS zone resource to use with the web_application_routing addon.
+      A comma separated list of resource IDs of the DNS zone resource to use with the App Routing addon.
     isPreview: true
   - name: --enable-high-log-scale-mode
     defaultValue: "False"

--- a/docs-ref-autogen/Latest-version/latest/aks.yml
+++ b/docs-ref-autogen/Latest-version/latest/aks.yml
@@ -585,7 +585,6 @@ directCommands:
       Enable the Kubernetes addons in a comma-separated list.
     description: |-
       These addons are available:
-          - http_application_routing : configure ingress with automatic public DNS name creation.
           - monitoring               : turn on Log Analytics monitoring. Uses the Log Analytics Default Workspace if it exists, else creates one.
                                        Specify "--workspace-resource-id" to use an existing workspace.
                                        Specify "--enable-msi-auth-for-monitoring" to use Managed Identity Auth.
@@ -1623,7 +1622,6 @@ directCommands:
       Enable the Kubernetes addons in a comma-separated list.
     description: |-
       These addons are available:
-      - http_application_routing        : configure ingress with automatic public DNS name creation.
       - monitoring                      :  turn on Log Analytics monitoring. Uses the Log Analytics Default Workspace if it exists, else creates one. Specify "--workspace-resource-id" to use an existing workspace. If monitoring addon is enabled --no-wait argument will have no effect
       - virtual-node                    : enable AKS Virtual Node. Requires --aci-subnet-name to provide the name of an existing subnet for the Virtual Node to use. aci-subnet-name must be in the same vnet which is specified by --vnet-subnet-id (required as well).
       - azure-policy                    : enable Azure policy. The Azure Policy add-on for AKS enables at-scale enforcements and safeguards on your clusters in a centralized, consistent manner. Required if enabling deployment safeguards. Learn more at aka.ms/aks/policy.
@@ -2396,7 +2394,6 @@ directCommands:
     Enable Kubernetes addons.
   description: |-
     These addons are available:
-    - http_application_routing : configure ingress with automatic public DNS name creation.
     - monitoring               : turn on Log Analytics monitoring. Requires "--workspace-resource-id".
                                  Requires "--enable-msi-auth-for-monitoring" for managed identity auth.
                                  Requires "--enable-syslog" to enable syslog data collection from nodes. Note MSI must be enabled.
@@ -2520,7 +2517,6 @@ directCommands:
     Enable Kubernetes addons.
   description: |-
     These addons are available:
-        http_application_routing        - configure ingress with automatic public DNS name creation.
         monitoring                      - turn on Log Analytics monitoring. Uses the Log Analytics Default Workspace if it exists, else creates one. Specify "--workspace-resource-id" to use an existing workspace.
                                           If monitoring addon is enabled --no-wait argument will have no effect
         virtual-node                    - enable AKS Virtual Node. Requires --subnet-name to provide the name of an existing subnet for the Virtual Node to use.

--- a/docs-ref-autogen/Latest-version/latest/aks/addon.yml
+++ b/docs-ref-autogen/Latest-version/latest/aks/addon.yml
@@ -59,7 +59,7 @@ directCommands:
         open-service-mesh               - enable Open Service Mesh addon (PREVIEW).
         gitops                          - enable GitOps (PREVIEW).
         azure-keyvault-secrets-provider - enable Azure Keyvault Secrets Provider addon.
-        web_application_routing         - enable Web Application Routing addon (PREVIEW). Specify "--dns-zone-resource-id" to configure DNS.
+        web_application_routing         - enable the App Routing addon (PREVIEW). Specify "--dns-zone-resource-id" to configure DNS.
   status: GA
   sourceType: Extension
   syntax: >-


### PR DESCRIPTION
# PR Summary
Removing references to "Web Application Routing" from the az aks cli reference. The add-on has been renamed to "App Routing" following GA, which is used elsewhere in the document. 

This PR also removes references to the now-deprecated http_application_routing_addon. New clusters are not able to enable this addon anymore.

Fixes [#31182 on az CLI](https://github.com/Azure/azure-cli/issues/31182)

## PR Checklist

<!--
    These items are mandatory. For your PR to be reviewed and merged,
    ensure you have followed these steps. As you complete the steps,
    check each box by replacing the space between the brackets with an
    x or by clicking on the box in the UI after your PR is submitted.
-->

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.

<!--
    If your PR is a work in progress, please mark it as a draft or
    prefix it with "(WIP)" or "WIP:"

    This helps us understand whether or not your PR is ready to review.
-->
