### PR TITLE
(AzureCXP) fixes MicrosoftDocs/azure-docs-cli#490048

### DIFF
--- a/docs-ref-conceptual/Latest-version/release-notes-azure-cli.md
+++ b/docs-ref-conceptual/Latest-version/release-notes-azure-cli.md
@@ -9,6 +9,10 @@ keywords: azure cli updates, azure cli notes, azure cli versions
 
 # Azure CLI release notes
 
+> [!NOTE]  
+> Previous Azure CLI versions and their release notes are available on the [Azure CLI GitHub Releases](https://github.com/Azure/azure-cli/releases) page.
+
+
 ## September 02, 2025
 
 Version 2.77.0


### PR DESCRIPTION
Updated line numbers 12-14
From
No reference in the article to where users can find previous Azure CLI versions or their release notes.
To
Added a NOTE box with a link to the Azure CLI GitHub Releases page, guiding users to access previous versions and their release notes.