### PR TITLE
Clarify mongodb services to avoid customer confusion. 

### DIFF
--- a/docs-ref-autogen/Latest-version/latest/mongo-db/atlas.yml
+++ b/docs-ref-autogen/Latest-version/latest/mongo-db/atlas.yml
@@ -4,6 +4,8 @@ name: az mongo-db atlas
 extensionInformation: |-
   > [!NOTE]
   > This reference is part of the **mongo-db** extension for the Azure CLI (version 2.70.0 or higher). The extension will automatically install the first time you run an **az mongo-db atlas** command. [Learn more](https://learn.microsoft.com/cli/azure/azure-cli-extensions-overview) about extensions.
+  >
+  > For Azure DocumentDB (with MongoDB compatibility), see https://learn.microsoft.com/azure/documentdb/.
 summary: |-
   Manage MongoDB Atlas.
 status: GA


### PR DESCRIPTION
PR Summary

This change adds a single link to Azure DocumentDB (with MongoDB compatibility) in the az mongo-db atlas Azure CLI reference note, helping readers distinguish Microsoft-managed MongoDB-compatible services from vendor-managed MongoDB Atlas since the current name "mongodb" leads to ambiguity and customer confusion. 

PR Checklist

 Descriptive Title: This PR's title is a synopsis of the changes it proposes.

 Summary: This PR's summary describes the scope and intent of the change.