### PR TITLE
(AzureCXP) fixes MicrosoftDocs/azure-docs-cli#546444

### DIFF
--- a/docs-ref-autogen/LTS-version/latest/afd/endpoint.yml
+++ b/docs-ref-autogen/LTS-version/latest/afd/endpoint.yml
@@ -232,7 +232,7 @@ directCommands:
   examples:
   - summary: |-
       Remove all cached contents under directory "/script" for domain www.contoso.com
-    syntax: az afd endpoint purge -g group --profile-name profile --domains www.contoso.com --content-paths '/scripts/*'
+    syntax: az afd endpoint purge -g group --profile-name profile --endpoint-name endpoint1 --domains www.contoso.com --content-paths '/scripts/*'
   requiredParameters:
   - isRequired: true
     name: --content-paths


### PR DESCRIPTION
I updated the purge command example to explicitly include the required --endpoint-name parameter, ensuring it matches the actual CLI requirements and prevents failures due to missing mandatory arguments.