### PR TITLE
Update installation script URL for Azure CLI on Linux

### DIFF
--- a/docs-ref-conceptual/Latest-version/includes/cli-install-linux-apt.md
+++ b/docs-ref-conceptual/Latest-version/includes/cli-install-linux-apt.md
@@ -29,7 +29,7 @@ If you wish to inspect the contents of the script yourself before executing, dow
 first using `curl` and inspect it in your favorite text editor.
 
 ```bash
-curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+curl -fsSL 'https://azurecliprod.blob.core.windows.net/$root/deb_install.sh' | sudo bash
 ```
 
 ### Option 2: Step-by-step installation instructions


### PR DESCRIPTION
We absolutely should not be using a vanity url for piping an install script to sudo bash. This opens up an attack vector in which anyone with access to update the vanity url could maliciously inject code into the users system. These vanity urls do not go through any sort of change management nor approvals. Any single individual with ownership of the url could make a change to point the url to a custom or private script which could then install malware or execute arbitrary code on the user's system.

We should update the documentation to point to the actual script, or use a method which requires more approval or change management to modify a script which we instruct users to run.