### PR TITLE
docs(stack-hci-vm): fix network summary typo

### DIFF
--- a/docs-ref-autogen/Latest-version/latest/stack-hci-vm/network.yml
+++ b/docs-ref-autogen/Latest-version/latest/stack-hci-vm/network.yml
@@ -5,7 +5,7 @@ extensionInformation: |-
   > [!NOTE]
   > This reference is part of the **stack-hci-vm** extension for the Azure CLI (version 2.15.0 or higher). The extension will automatically install the first time you run an **az stack-hci-vm network** command. [Learn more](https://learn.microsoft.com/cli/azure/azure-cli-extensions-overview) about extensions.
 summary: |-
-  Manage network with stack-hvi-vm.
+  Manage network with stack-hci-vm.
 status: GA
 sourceType: Extension
 commands:
@@ -87,4 +87,4 @@ commands:
 - az_stack-hci-vm_network_vnet_subnet_update
 - az_stack-hci-vm_network_vnet_update
 metadata:
-  description: Manage network with stack-hvi-vm.
+  description: Manage network with stack-hci-vm.


### PR DESCRIPTION
## Summary

- fix `stack-hvi-vm` -> `stack-hci-vm` in the `az stack-hci-vm network` summary and metadata description

## Testing

- verified both displayed descriptions now use the correct command name

Closes #32586
