### PR TITLE
docs(bicep): fix publish --force example

### DIFF
--- a/docs-ref-autogen/Latest-version/latest/bicep.yml
+++ b/docs-ref-autogen/Latest-version/latest/bicep.yml
@@ -729,7 +729,7 @@ directCommands:
     syntax: az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag}"
   - summary: |-
       Publish a bicep file overwriting an existing tag.
-    syntax: az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag} --force"
+    syntax: az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag}" --force
   - summary: |-
       Publish a bicep file with documentation uri.
     syntax: az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag}" --documentation-uri {documentation_uri}


### PR DESCRIPTION
## Summary

- move `--force` outside the quoted `--target` value in the `az bicep publish` example

## Testing

- verified the example now matches the issue report and keeps the target reference correctly quoted

Closes #32786
