### PR TITLE
docs: fix bicep publish force example

### DIFF
--- a/docs-ref-autogen/Latest-version/latest/bicep.yml
+++ b/docs-ref-autogen/Latest-version/latest/bicep.yml
@@ -729,7 +729,7 @@ directCommands:
     syntax: az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag}"
   - summary: |-
       Publish a bicep file overwriting an existing tag.
-    syntax: az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag} --force"
+    syntax: az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag}" --force
   - summary: |-
       Publish a bicep file with documentation uri.
     syntax: az bicep publish --file {bicep_file} --target "br:{registry}/{module_path}:{tag}" --documentation-uri {documentation_uri}


### PR DESCRIPTION
## Summary
- Move `--force` outside the quoted `--target` value in the `az bicep publish` example.
- This matches the command syntax where `--force` is a separate option.

Addresses Azure/azure-cli#32786.

## Testing
- `rg -n "az bicep publish --file \{bicep_file\} --target" docs-ref-autogen\Latest-version\latest\bicep.yml`
- `git diff --check`

## AI disclosure
This pull request was prepared with assistance from OpenAI Codex.