### PR TITLE
the desription of the parameter vnet-subnet-id is incorrect

### DIFF
--- a/docs-ref-autogen/LTS-version/latest/aks/nodepool.yml
+++ b/docs-ref-autogen/LTS-version/latest/aks/nodepool.yml
@@ -261,7 +261,7 @@ directCommands:
       Space-separated tags: key[=value] [key[=value] ...]. Use "" to clear existing tags.
   - name: --vnet-subnet-id
     summary: |-
-      The Resource Id of a subnet in an existing VNet into which to deploy the cluster.
+      The Resource Id of a subnet in an existing VNet into which to deploy the nodepool.
   - name: --zones -z
     summary: |-
       Availability zones where agent nodes will be placed. Also, to install agent nodes to more than one zone you need to pass zone numbers separated by blanks.  For example -  To have all 3 zones, you are expected to enter `--zones 1 2 3`.


### PR DESCRIPTION


# PR Summary
the parameter "--vnet-subnet-id" in this context is to specify on which subnet we want to deploy our nodepool and not the cluster

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.

