### PR TITLE
Add guidance for client secrets starting with hyphens

### DIFF
--- a/docs-ref-conceptual/Latest-version/authenticate-azure-cli-service-principal.md
+++ b/docs-ref-conceptual/Latest-version/authenticate-azure-cli-service-principal.md
@@ -3,6 +3,7 @@ title: Sign in with Azure CLI using a service principal
 description: Learn how to sign into Azure using a service principal and the Azure CLI. Find an example for appending a certification to a private key.
 ms.service: azure-cli
 ms.custom: devx-track-azurecli
+ms.date: 08/05/2026
 #customer intent: As an app developer, I need to security automate authentication to Azure using a service principal.
 ---
 
@@ -36,6 +37,15 @@ To log in with a client secret, use the following command:
 ```azurecli-interactive
 az login --service-principal --username APP_ID --password CLIENT_SECRET --tenant TENANT_ID
 ```
+
+> [!TIP]
+> If your client secret starts with a special character such as a hyphen (`-`), the shell or CLI
+> parser might interpret it as an option flag. To avoid this issue, use the `=` syntax to attach the
+> value directly to the parameter:
+>
+> ```azurecli-interactive
+> az login --service-principal --username APP_ID --password=CLIENT_SECRET --tenant TENANT_ID
+> ```
 
 To log in with a certificate, use the following command:
 


### PR DESCRIPTION
# PR Summary

Adds a TIP block to the service principal authentication article explaining how to handle client secrets that start with special characters (such as hyphens). When a secret begins with `-`, the CLI parser can misinterpret it as an option flag. The fix shows `--password=CLIENT_SECRET` syntax to avoid this issue.

- Fixes #6096

## PR Checklist

- [x] **Descriptive Title:** This PR's title is a synopsis of the changes it proposes.
- [x] **Summary:** This PR's summary describes the scope and intent of the change.

## Related work items

[AB#607019](https://dev.azure.com/msft-skilling/Content/_workitems/edit/607019) — Fix service principal login guidance for secrets starting with hyphens

> [!NOTE]
> This PR description was generated by CDA Cortex and may require review for accuracy.